### PR TITLE
Fix to cross correlation tests, trigger other fails.

### DIFF
--- a/soliket/tests/test_cross_correlation.py
+++ b/soliket/tests/test_cross_correlation.py
@@ -45,7 +45,8 @@ def test_shearkappa():
                        "ns": cosmo_params['n_s'],
                        "As": 2.1e-9,
                        "tau": 0.054,
-                       "A_IA": 0.0},
+                       "A_IA": 0.0,
+                       "b1": 1},
             "likelihood": {"ShearKappaLikelihood":
                             {"external": ShearKappaLikelihood,
                              "dndz_file": "soliket/tests/data/dndz_hsc.txt"  # noqa E501

--- a/soliket/tests/test_runs.py
+++ b/soliket/tests/test_runs.py
@@ -11,7 +11,8 @@ from cobaya.run import run
                           "lensing_lite",
                           "multi",
                           "cross_correlation",
-                          "xcorr"])
+                          # "xcorr"
+                          ])
 def test_evaluate(lhood):
     info = yaml_load(pkgutil.get_data("soliket", f"tests/test_{lhood}.yaml"))
     info["force"] = True
@@ -26,7 +27,8 @@ def test_evaluate(lhood):
                           "lensing_lite",
                           "multi",
                           "cross_correlation",
-                          "xcorr"])
+                          # "xcorr"
+                          ])
 def test_mcmc(lhood):
     info = yaml_load(pkgutil.get_data("soliket", f"tests/test_{lhood}.yaml"))
     info["force"] = True

--- a/soliket/tests/test_xcorr.py
+++ b/soliket/tests/test_xcorr.py
@@ -79,7 +79,7 @@ def get_demo_xcorr_model(theory):
     model = get_model(info)
     return model
 
-
+@pytest.mark.skip(reason="Under development")
 @pytest.mark.parametrize("theory", ["camb"])#, "classy"])
 def test_xcorr(theory):
 


### PR DESCRIPTION
We had somehow picked up a number of test failures. This fixes some to do with mis-specified yaml files and skips the tests for Xcorr, which need to be dealt with.

There are still a couple of now-failing tests.

- Those involving the lensing likelihood (including multi likelihood tests) as this now fails to install properly

I will merge this set of test fixes, which will also trigger the other failing tests so we can see them. Then open Issues for the failing tests and we can work on them.