### PR TITLE
Add CosmoPower P(k,z)

### DIFF
--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -19,9 +19,11 @@ from cobaya.typing import InfoDict
 class CosmoPower(BoltzmannBase):
     soliket_data_path: str = "soliket/data/CosmoPower"
     network_path: str = "CP_paper/CMB"
+    network_path_pk: str = "CP_paper/PK"
     cmb_tt_nn_filename: str = "cmb_TT_NN"
     cmb_te_pcaplusnn_filename: str = "cmb_TE_PCAplusNN"
     cmb_ee_nn_filename: str = "cmb_EE_NN"
+    pk_lin_nn_filename: str = "PKLIN_NN"
 
     extra_args: InfoDict = {}
 


### PR DESCRIPTION
Merging will close #84 

Some things to think about so far:
- Will build this out because I want to use it in a Likelihood (CrossCorrelationLikelihood) which needs a Pk (delta_tot, delta_tot) grid. It would be better to use the full machinery inhereted from BoltzmannBase.
- CosmoPower networks do not contain metadata about valid parameter ranges. It would be good to think about a way of packaging them with it and then using them here to prevent sampling outside those ranges.
- I don't know how to manage that different params are supported for Pk than tt, te, ee.