### PR TITLE
Change to tox for tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,6 +39,16 @@ jobs:
     - name: Install Dependencies
       run: |
         pip install tox
+    - name: Install Classy
+      run: |
+        if [[ ${MATRIX_OS} == "macos-latest" ]]; then
+          . ci_scripts/install_class_osx.sh
+        else
+          . ci_scripts/install_class_linux.sh
+        fi
+        python -c "import classy; print(classy)"
+      env:
+        MATRIX_OS: ${{ matrix.os }}
     - name: Run Tests
       run: |
         tox -e ${{ matrix.toxenv }} ${{ matrix.toxargs }} -- ${{ matrix.toxposargs }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         mamba install \
           pip \
-          numpy nose coveralls pyyaml gsl fftw cmake swig scipy \
+          numpy tox nose coveralls pyyaml gsl fftw cmake swig scipy \
           compilers pkg-config setuptools_scm pytest pandas pytest-cov \
           cython "camb>=1.3" isitgr traitlets fast-pt pyccl
         if [[ ${MATRIX_OS} == "macos-11" ]]; then

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,63 +13,42 @@ jobs:
 
           - name: latest supported versions
             os: ubuntu-latest
-            python: '3.10'
+            python-version: '3.10'
             toxenv: python3.10-test-all-latest-cov
             toxposargs: --cov-report=xml:${GITHUB_WORKSPACE}/coverage.xml
 
           - name: oldest supported versions
             os: ubuntu-latest
-            python: '3.7'
+            python-version: '3.7'
             toxenv: python3.7-test-oldest
 
-          - name: macOS latest supported
-            os: macos-latest
-            python: '3.10'
+          - name: macOS 11
+            os: macos-11
+            python-version: '3.10'
             toxenv: python3.10-test-latest
 
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install Python ${{ matrix.python }}
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python }}
-        channels: conda-forge,defaults
-        channel-priority: strict
-        show-channel-urls: true
-        miniforge-version: latest
-        miniforge-variant: Mambaforge
-    - name: Install Dependencies
-      run: |
-        mamba install \
-          pip \
-          numpy nose coveralls pyyaml gsl fftw cmake swig scipy \
-          compilers pkg-config setuptools_scm pytest pandas pytest-cov \
-          cython "camb>=1.3" isitgr traitlets fast-pt pyccl
-        pip install tox
-        if [[ ${MATRIX_OS} == "macos-11" ]]; then
-          mamba install llvm-openmp
-          echo "DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib" >> $GITHUB_ENV
-          SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
-          echo "SDKROOT: ${SDKROOT}"
-          echo "SDKROOT=${SDKROOT}" >> $GITHUB_ENV
-          echo "CONDA_BUILD_SYSROOT=${SDKROOT}" >> $GITHUB_ENV
-        fi
-    # - name: Install Classy
-    #   run: |
-    #     if [[ ${MATRIX_OS} == "macos-latest" ]]; then
-    #       export LDFLAGS="-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
-    #       export LDFLAGS="$LDFLAGS -L/Users/runner/miniconda3/envs/test/lib"
-    #       . ci_scripts/install_class_osx.sh
-    #     else
-    #       . ci_scripts/install_class_linux.sh
-    #     fi
-    #     python -c "import classy; print(classy)"
-      env:
-        MATRIX_OS: ${{ matrix.os }}
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install Conda w/ Python ${{ matrix.python-version }}
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: soliket-tests
+          environment-file: soliket-tests.yml
+          auto-activate-base: false
+          python-version: ${{ matrix.python-version }}
+          use-mamba: true
+          miniforge-variant: Mambaforge
+     - name: Install class
+        shell: bash -el {0}
+        run: |
+          if [[ ${MATRIX_OS} == "ubuntu-latest" ]]; then
+            pip install classy
+          fi
+        env:
+          MATRIX_OS: ${{ matrix.os }}
     - name: Run Tests
+      shell: bash -el {0}
       run: |
         tox -e ${{ matrix.toxenv }} ${{ matrix.toxargs }} -- ${{ matrix.toxposargs }}
     - if: contains(matrix.toxenv, '-cov')

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           use-mamba: true
           miniforge-variant: Mambaforge
-      - if contains(matrix.os, 'ubuntu')
+      - if: contains(matrix.os, 'ubuntu')
         name: Install class
         shell: bash -el {0}
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -42,20 +42,20 @@ jobs:
         miniforge-version: latest
         miniforge-variant: Mambaforge
     - name: Install Dependencies
-        run: |
-          mamba install \
-            pip \
-            numpy nose coveralls pyyaml gsl fftw cmake swig scipy \
-            compilers pkg-config setuptools_scm pytest pandas pytest-cov \
-            cython "camb>=1.3" isitgr traitlets fast-pt pyccl
-          if [[ ${MATRIX_OS} == "macos-11" ]]; then
-            mamba install llvm-openmp
-            echo "DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib" >> $GITHUB_ENV
-            SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
-            echo "SDKROOT: ${SDKROOT}"
-            echo "SDKROOT=${SDKROOT}" >> $GITHUB_ENV
-            echo "CONDA_BUILD_SYSROOT=${SDKROOT}" >> $GITHUB_ENV
-          fi
+      run: |
+        mamba install \
+          pip \
+          numpy nose coveralls pyyaml gsl fftw cmake swig scipy \
+          compilers pkg-config setuptools_scm pytest pandas pytest-cov \
+          cython "camb>=1.3" isitgr traitlets fast-pt pyccl
+        if [[ ${MATRIX_OS} == "macos-11" ]]; then
+          mamba install llvm-openmp
+          echo "DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib" >> $GITHUB_ENV
+          SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+          echo "SDKROOT: ${SDKROOT}"
+          echo "SDKROOT=${SDKROOT}" >> $GITHUB_ENV
+          echo "CONDA_BUILD_SYSROOT=${SDKROOT}" >> $GITHUB_ENV
+        fi
     - name: Install Classy
       run: |
         if [[ ${MATRIX_OS} == "macos-latest" ]]; then

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,9 +45,10 @@ jobs:
       run: |
         mamba install \
           pip \
-          numpy tox nose coveralls pyyaml gsl fftw cmake swig scipy \
+          numpy nose coveralls pyyaml gsl fftw cmake swig scipy \
           compilers pkg-config setuptools_scm pytest pandas pytest-cov \
           cython "camb>=1.3" isitgr traitlets fast-pt pyccl
+        pip install tox
         if [[ ${MATRIX_OS} == "macos-11" ]]; then
           mamba install llvm-openmp
           echo "DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib" >> $GITHUB_ENV

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,7 @@ jobs:
 
           - name: oldest supported versions
             os: ubuntu-latest
-            python: 3.7
+            python: '3.7'
             toxenv: py37-test-oldest
 
           - name: macOS latest supported
@@ -35,7 +35,7 @@ jobs:
     - name: Install Python ${{ matrix.python }}
       uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: ${{ matrix.py }}
+        python-version: ${{ matrix.python }}
         channels: conda-forge,defaults
         channel-priority: strict
         show-channel-urls: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -56,16 +56,16 @@ jobs:
           echo "SDKROOT=${SDKROOT}" >> $GITHUB_ENV
           echo "CONDA_BUILD_SYSROOT=${SDKROOT}" >> $GITHUB_ENV
         fi
-    - name: Install Classy
-      run: |
-        if [[ ${MATRIX_OS} == "macos-latest" ]]; then
-          export LDFLAGS="-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
-          export LDFLAGS="$LDFLAGS -L/Users/runner/miniconda3/envs/test/lib"
-          . ci_scripts/install_class_osx.sh
-        else
-          . ci_scripts/install_class_linux.sh
-        fi
-        python -c "import classy; print(classy)"
+    # - name: Install Classy
+    #   run: |
+    #     if [[ ${MATRIX_OS} == "macos-latest" ]]; then
+    #       export LDFLAGS="-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
+    #       export LDFLAGS="$LDFLAGS -L/Users/runner/miniconda3/envs/test/lib"
+    #       . ci_scripts/install_class_osx.sh
+    #     else
+    #       . ci_scripts/install_class_linux.sh
+    #     fi
+    #     python -c "import classy; print(classy)"
       env:
         MATRIX_OS: ${{ matrix.os }}
     - name: Run Tests

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,66 +3,45 @@ name: Testing
 on: [push, pull_request]
 
 jobs:
-  build:
-
+  test:
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash -l {0}    
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        include:
+
+          - name: latest supported versions
+            os: ubuntu-latest
+            python: '3.10'
+            toxenv: py310-test-all-latest-cov
+            toxposargs: --cov-report=xml:${GITHUB_WORKSPACE}/coverage.xml
+
+          - name: oldest supported versions
+            os: ubuntu-latest
+            python: 3.7
+            toxenv: py37-test-oldest
+
+          - name: macOS latest supported
+            os: macos-latest
+            python: '3.10'
+            toxenv: py310-test-latest
+
     steps:
-    - uses: actions/checkout@v2
-
-    - uses: conda-incubator/setup-miniconda@v2
+    - name: Checkout Repository
+      uses: actions/checkout@v2
       with:
-        python-version: ${{ matrix.py }}
-        auto-update-conda: true
-        channels: conda-forge,defaults
-        channel-priority: strict
-        show-channel-urls: true
-
-    - name: install reqs
+        fetch-depth: 0
+    - name: Install Python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install Dependencies
       run: |
-        conda install pip compilers pytest pytest-cov pyccl cython
-        pip install cobaya
-
-    - name: install extra reqs
+        pip install tox
+    - name: Run Tests
       run: |
-        pip install cosmopower
-
-      env:  
-        MATRIX_OS: ${{ matrix.os }}
-
-    - name: Install classy
-      run: |
-        if [[ ${MATRIX_OS} == "macos-latest" ]]; then
-          . ci_scripts/install_class_osx.sh
-        else
-          . ci_scripts/install_class_linux.sh
-        fi
-        python -c "import classy; print(classy)"
-      env:
-        MATRIX_OS: ${{ matrix.os }}
-
-    - name: install
-      run: |
-        pip install .
-
-    - name: install test data
-      run: |
-        export COBAYA_PACKAGES_PATH="../packages"
-        cobaya-install planck_2018_highl_plik.TTTEEE_lite_native
-
-    - name: Unit tests
-      run: |
-        pytest -vv soliket --cov=soliket --cov-report=xml:coverage.xml --cov-config=setup.cfg
-      env:
-        PYTEST_ADDOPTS: "--color=yes"
-
-    - name: Report Coverage (codecov)
-      if: matrix.os == 'ubuntu-latest'
-      uses: codecov/codecov-action@v2
+        tox -e ${{ matrix.toxenv }} ${{ matrix.toxargs }} -- ${{ matrix.toxposargs }}
+    - if: contains(matrix.toxenv, '-cov')
+      name: Report Coverage
+      uses: codecov/codecov-action@v1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,18 +39,17 @@ jobs:
           python-version: ${{ matrix.python-version }}
           use-mamba: true
           miniforge-variant: Mambaforge
-     - name: Install class
+      - if contains(matrix.os, 'ubuntu')
+        name: Install class
         shell: bash -el {0}
         run: |
-          if [[ ${MATRIX_OS} == "ubuntu-latest" ]]; then
-            pip install classy
-          fi
+          pip install classy
         env:
           MATRIX_OS: ${{ matrix.os }}
-    - name: Run Tests
-      shell: bash -el {0}
-      run: |
-        tox -e ${{ matrix.toxenv }} ${{ matrix.toxargs }} -- ${{ matrix.toxposargs }}
-    - if: contains(matrix.toxenv, '-cov')
-      name: Report Coverage
-      uses: codecov/codecov-action@v1
+      - name: Run Tests
+        shell: bash -el {0}
+        run: |
+          tox -e ${{ matrix.toxenv }} ${{ matrix.toxargs }} -- ${{ matrix.toxposargs }}
+      - if: contains(matrix.toxenv, '-cov')
+        name: Report Coverage
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,15 +33,34 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: ${{ matrix.python }}
+        python-version: ${{ matrix.py }}
+        channels: conda-forge,defaults
+        channel-priority: strict
+        show-channel-urls: true
+        miniforge-version: latest
+        miniforge-variant: Mambaforge
     - name: Install Dependencies
-      run: |
-        pip install tox
+        run: |
+          mamba install \
+            pip \
+            numpy nose coveralls pyyaml gsl fftw cmake swig scipy \
+            compilers pkg-config setuptools_scm pytest pandas pytest-cov \
+            cython "camb>=1.3" isitgr traitlets fast-pt pyccl
+          if [[ ${MATRIX_OS} == "macos-11" ]]; then
+            mamba install llvm-openmp
+            echo "DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib" >> $GITHUB_ENV
+            SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+            echo "SDKROOT: ${SDKROOT}"
+            echo "SDKROOT=${SDKROOT}" >> $GITHUB_ENV
+            echo "CONDA_BUILD_SYSROOT=${SDKROOT}" >> $GITHUB_ENV
+          fi
     - name: Install Classy
       run: |
         if [[ ${MATRIX_OS} == "macos-latest" ]]; then
+          export LDFLAGS="-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
+          export LDFLAGS="$LDFLAGS -L/Users/runner/miniconda3/envs/test/lib"
           . ci_scripts/install_class_osx.sh
         else
           . ci_scripts/install_class_linux.sh

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,18 +14,18 @@ jobs:
           - name: latest supported versions
             os: ubuntu-latest
             python: '3.10'
-            toxenv: py310-test-all-latest-cov
+            toxenv: python3.10-test-all-latest-cov
             toxposargs: --cov-report=xml:${GITHUB_WORKSPACE}/coverage.xml
 
           - name: oldest supported versions
             os: ubuntu-latest
             python: '3.7'
-            toxenv: py37-test-oldest
+            toxenv: python3.7-test-oldest
 
           - name: macOS latest supported
             os: macos-latest
             python: '3.10'
-            toxenv: py310-test-latest
+            toxenv: python3.10-test-latest
 
     steps:
     - name: Checkout Repository

--- a/ci_scripts/install_class_osx.sh
+++ b/ci_scripts/install_class_osx.sh
@@ -7,7 +7,8 @@ git clone --depth=1000 https://github.com/lesgourg/class_public.git
 cd class_public
 
 # if you are running on macos 11.6 and higher, uncomment the following line
-sed -i.bak -e 's/gcc/gcc-9/g' Makefile
+# sed -i.bak -e 's/gcc/gcc-9/g' Makefile
+sed -i.bak -e 's/^OMPFLAG/#OMPFLAG/g' Makefile
 
 # if you are running on macos 10.15 and lower, uncomment the following 4 lines
 #sed -i.bak -e 's/^CC/#CC/g' Makefile

--- a/ci_scripts/install_class_osx.sh
+++ b/ci_scripts/install_class_osx.sh
@@ -5,16 +5,20 @@ export CONDA_BUILD_SYSROOT=/
 rm -rf class_public
 git clone --depth=1000 https://github.com/lesgourg/class_public.git
 cd class_public
+git checkout v2.7.2
 
-# if you are running on macos 11.6 and higher, uncomment the following line
-# sed -i.bak -e 's/gcc/gcc-9/g' Makefile
-sed -i.bak -e 's/^OMPFLAG/#OMPFLAG/g' Makefile
+echo "----------------------------------"
+env
+echo "----------------------------------"
 
-# if you are running on macos 10.15 and lower, uncomment the following 4 lines
-#sed -i.bak -e 's/^CC/#CC/g' Makefile
-#sed -i.bak -e 's/^OPTFLAG =/OPTFLAG = ${CFLAGS} ${LDFLAGS}/g' Makefile
-#sed -i.bak -e 's/^#CCFLAG +=/CCFLAG +=/g' Makefile
-#sed -i.bak -e 's/^#CCFLAG =/CCFLAG =/g' Makefile
+sed -i.bak -e 's/^CC/#CC/g' Makefile
+sed -i.bak -e 's/^OPTFLAG =/OPTFLAG = ${CFLAGS} ${LDFLAGS}/g' Makefile
+sed -i.bak -e 's/^#CCFLAG +=/CCFLAG +=/g' Makefile
+sed -i.bak -e 's/^#CCFLAG =/CCFLAG =/g' Makefile
+
+echo "----------------------------------"
+cat Makefile
+echo "----------------------------------"
 
 make -j4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+
+requires = ["setuptools",
+            "setuptools_scm",
+            "wheel"]
+
+build-backend = 'setuptools.build_meta'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,21 @@
+tox
+numpy
+scipy
+pandas
+scikit-learn
+pyyaml
+py-bobyqa
+packaging
+tqdm
+portalocker
+dill
+fuzzywuzzy
+astropy
+camb
+cosmopower
+getdist
+cobaya
+pyccl
+sacc
+fgspectra @ git+https://github.com/simonsobs/fgspectra@act_sz_x_cib#egg=fgspectra
+mflike @ git+https://github.com/simonsobs/lat_mflike@master

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,14 +9,6 @@ packages = find:
 python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
-    astropy>=4
-    scikit-learn
-    cobaya
-    sacc
-    pyccl
-    fgspectra @ git+https://github.com/simonsobs/fgspectra@act_sz_x_cib#egg=fgspectra
-    mflike @ git+https://github.com/simonsobs/lat_mflike@master
-    camb
 
 [options.extras_require]
 test =

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,18 +11,10 @@ setup_requires = setuptools_scm
 install_requires =
 
 [options.extras_require]
-test =
-    pytest-astropy
-    pytest-rerunfailures
-all =
-    pytest-astropy
-    pytest-rerunfailures
-    cosmopower
 
 [options.package_data]
 soliket = *.yaml,*.bibtex,clusters/data/*,clusters/data/selFn_equD56/*,lensing/data/*.txt,mflike/*.yaml
 testpaths = "soliket"
-astropy_header = true
 text_file_format = rst
 
 [coverage:run]

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ all =
     cosmopower
 
 [options.package_data]
-soliket = *.yaml,*.bibtex,clusters/data/*,clusters/data/selFn_equD56/*,lensing/data/*.txt
+soliket = *.yaml,*.bibtex,clusters/data/*,clusters/data/selFn_equD56/*,lensing/data/*.txt,mflike/*.yaml
 testpaths = "soliket"
 astropy_header = true
 text_file_format = rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,14 +9,8 @@ packages = find:
 python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
-#    compilers
-#    cmake
-#    swig
-#    cython
     astropy>=4
     scikit-learn
-#    numpy
-#    scipy
     cobaya
     sacc
     pyccl

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@ name = soliket
 version = 0.0
 description = "SO Likelihoods & Theories"
 
-
 [options]
 zip_safe = False
 packages = find:
@@ -11,6 +10,8 @@ python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     compilers
+    cmake
+    swig
     cython
     astropy>=4
     scikit-learn
@@ -21,13 +22,15 @@ install_requires =
     pyccl
     fgspectra @ git+https://github.com/simonsobs/fgspectra@act_sz_x_cib#egg=fgspectra
     mflike @ git+https://github.com/simonsobs/lat_mflike@master
+    camb
 
 [options.extras_require]
 test =
     pytest-astropy
     pytest-rerunfailures
-    cosmopower
 all =
+    pytest-astropy
+    pytest-rerunfailures
     cosmopower
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,14 +9,14 @@ packages = find:
 python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
-    compilers
-    cmake
-    swig
-    cython
+#    compilers
+#    cmake
+#    swig
+#    cython
     astropy>=4
     scikit-learn
-    numpy
-    scipy
+#    numpy
+#    scipy
     cobaya
     sacc
     pyccl

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,40 @@
-[flake8]
-select = E713,E704,E703,E714,E741,E10,E11,E20,E22,E23,E25,E27,E301,E302,E304,E9,
-		 F405,F406,F5,F6,F7,F8,W1,W2,W3,W6,E501
-max-line-length = 90
-exclude = .tox,build
+[metadata]
+name = soliket
+version = 0.0
+description = "SO Likelihoods & Theories"
+
+
+[options]
+zip_safe = False
+packages = find:
+python_requires = >=3.7
+setup_requires = setuptools_scm
+install_requires =
+    compilers
+    cython
+    astropy>=4
+    scikit-learn
+    numpy
+    scipy
+    cobaya
+    sacc
+    pyccl
+    fgspectra @ git+https://github.com/simonsobs/fgspectra@act_sz_x_cib#egg=fgspectra
+    mflike @ git+https://github.com/simonsobs/lat_mflike@master
+
+[options.extras_require]
+test =
+    pytest-astropy
+    pytest-rerunfailures
+    cosmopower
+all =
+    cosmopower
+
+[options.package_data]
+soliket = *.yaml,*.bibtex,clusters/data/*,clusters/data/selFn_equD56/*,lensing/data/*.txt
+testpaths = "soliket"
+astropy_header = true
+text_file_format = rst
 
 [coverage:run]
 omit =
@@ -27,3 +59,9 @@ exclude_lines =
     pragma: py{ignore_python_version}
     # Don't complain about IPython completion helper
     def _ipython_key_completions_
+
+[flake8]
+select = E713,E704,E703,E714,E741,E10,E11,E20,E22,E23,E25,E27,E301,E302,E304,E9,
+         F405,F406,F5,F6,F7,F8,W1,W2,W3,W6,E501
+max-line-length = 90
+exclude = .tox,build

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,78 @@
-# example cobaya-compliant SO likelihood package;
-# adapted from github.com/cobayasampler/example_external_likelihood
+#!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# NOTE: The configuration for the package, including the name, version, and
+# other information are set in the setup.cfg file.
+
+import os
+import sys
 
 from setuptools import setup
 
-setup(
-    name="soliket",
-    version="0.0",
-    description="SO Likelihoods & Theories",
-    zip_safe=False,
-    packages=["soliket", "soliket.tests", "soliket.clusters"],
-    package_data={
-        "soliket": [
-            "*.yaml",
-            "*.bibtex",
-            # "data/simulated*/*.txt",
-            "clusters/data/*",
-            "clusters/data/selFn_equD56/*",
-            "lensing/data/*.txt",
-        ]
-    },
-    install_requires=[
-        "astropy",
-        "scikit-learn",
-        "cobaya",
-        "sacc",
-        "pyccl",
-        "fgspectra @ git+https://github.com/simonsobs/fgspectra@act_sz_x_cib#egg=fgspectra", # noqa E501
-        "mflike @ git+https://github.com/simonsobs/lat_mflike@master"
-    ],
-    extras_requires=[
-        "cosmopower"
-    ],
-    test_suite="soliket.tests",
-    include_package_data=True,
-)
+
+# First provide helpful messages if contributors try and run legacy commands
+# for tests or docs.
+
+TEST_HELP = """
+Note: running tests is no longer done using 'python setup.py test'. Instead
+you will need to run:
+
+    tox -e test
+
+If you don't already have tox installed, you can install it with:
+
+    pip install tox
+
+If you only want to run part of the test suite, you can also use pytest
+directly with::
+
+    pip install -e .[test]
+    pytest
+
+For more information, see:
+
+  http://docs.astropy.org/en/latest/development/testguide.html#running-tests
+"""
+
+if 'test' in sys.argv:
+    print(TEST_HELP)
+    sys.exit(1)
+
+DOCS_HELP = """
+Note: building the documentation is no longer done using
+'python setup.py build_docs'. Instead you will need to run:
+
+    tox -e build_docs
+
+If you don't already have tox installed, you can install it with:
+
+    pip install tox
+
+You can also build the documentation with Sphinx directly using::
+
+    pip install -e .[docs]
+    cd docs
+    make html
+
+For more information, see:
+
+  http://docs.astropy.org/en/latest/install.html#builddocs
+"""
+
+if 'build_docs' in sys.argv or 'build_sphinx' in sys.argv:
+    print(DOCS_HELP)
+    sys.exit(1)
+
+VERSION_TEMPLATE = """
+# Note that we need to fall back to the hard-coded version if either
+# setuptools_scm can't be imported or setuptools_scm can't determine the
+# version, so we catch the generic 'Exception'.
+try:
+    from setuptools_scm import get_version
+    version = get_version(root='..', relative_to=__file__)
+except Exception:
+    version = '{version}'
+""".lstrip()
+
+setup(use_scm_version={'write_to': os.path.join('soliket', 'version.py'),
+                       'write_to_template': VERSION_TEMPLATE})

--- a/soliket-tests.yml
+++ b/soliket-tests.yml
@@ -1,0 +1,14 @@
+name: soliket-tests
+channels:
+
+dependencies:
+  - python<=3.10
+  - pip
+  - compilers
+  - cmake
+  - gsl
+  - fftw
+  - cython
+  - mpi4py
+  - pip:
+      - -r requirements.txt

--- a/soliket-tests.yml
+++ b/soliket-tests.yml
@@ -10,5 +10,7 @@ dependencies:
   - fftw
   - cython
   - mpi4py
+  - pytest
+  - pytest-forked
   - pip:
       - -r requirements.txt

--- a/soliket/tests/test_cosmopower.py
+++ b/soliket/tests/test_cosmopower.py
@@ -42,13 +42,15 @@ info_dict = {
 
 @pytest.mark.skipif(not HAS_COSMOPOWER, reason='test requires cosmopower')
 def test_cosmopower_theory(request):
-    info_dict['theory']['soliket.CosmoPower']['soliket_data_path'] = os.path.join(request.config.rootdir, 'soliket/data/CosmoPower')
+    info_dict['theory']['soliket.CosmoPower']['soliket_data_path'] = \
+        os.path.join(request.config.rootdir, 'soliket/data/CosmoPower')
     model_fiducial = get_model(info_dict)   # noqa F841
 
 
 @pytest.mark.skipif(not HAS_COSMOPOWER, reason='test requires cosmopower')
 def test_cosmopower_loglike(request):
-    info_dict['theory']['soliket.CosmoPower']['soliket_data_path'] = os.path.join(request.config.rootdir, 'soliket/data/CosmoPower')
+    info_dict['theory']['soliket.CosmoPower']['soliket_data_path'] = \
+        os.path.join(request.config.rootdir, 'soliket/data/CosmoPower')
     model_cp = get_model(info_dict)
 
     logL_cp = float(model_cp.loglikes({})[0])
@@ -66,7 +68,8 @@ def test_cosmopower_against_camb(request):
 
     info_dict['theory'] = {
                            "soliket.CosmoPower": {
-                           "soliket_data_path": os.path.join(request.config.rootdir, 'soliket/data/CosmoPower'),
+                           "soliket_data_path": os.path.join(request.config.rootdir,
+                                                             'soliket/data/CosmoPower'),
                            "stop_at_error": True,
                            "extra_args": {'lmax': camb_cls['ell'].max() + 1}}
         }

--- a/soliket/tests/test_cosmopower.py
+++ b/soliket/tests/test_cosmopower.py
@@ -31,9 +31,9 @@ info_dict = {
     "theory": {
         "soliket.CosmoPower": {
             # "soliket_data_path": os.path.normpath(
-            #     os.path.join(os.getcwd(), "../data/CosmoPower")
+            #     os.path.join(os.getcwd(), "soliket/data/CosmoPower")
             # ),
-            "soliket_data_path": "soliket/data/CosmoPower",
+            # "soliket_data_path": "soliket/data/CosmoPower",
             "stop_at_error": True,
         }
     },
@@ -41,12 +41,14 @@ info_dict = {
 
 
 @pytest.mark.skipif(not HAS_COSMOPOWER, reason='test requires cosmopower')
-def test_cosmopower_theory():
+def test_cosmopower_theory(request):
+    info_dict['theory']['soliket.CosmoPower']['soliket_data_path'] = os.path.join(request.config.rootdir, 'soliket/data/CosmoPower')
     model_fiducial = get_model(info_dict)   # noqa F841
 
 
 @pytest.mark.skipif(not HAS_COSMOPOWER, reason='test requires cosmopower')
-def test_cosmopower_loglike():
+def test_cosmopower_loglike(request):
+    info_dict['theory']['soliket.CosmoPower']['soliket_data_path'] = os.path.join(request.config.rootdir, 'soliket/data/CosmoPower')
     model_cp = get_model(info_dict)
 
     logL_cp = float(model_cp.loglikes({})[0])
@@ -55,7 +57,7 @@ def test_cosmopower_loglike():
 
 
 @pytest.mark.skipif(not HAS_COSMOPOWER, reason='test requires cosmopower')
-def test_cosmopower_against_camb():
+def test_cosmopower_against_camb(request):
 
     info_dict['theory'] = {'camb': {'stop_at_error': True}}
     model_camb = get_model(info_dict)
@@ -64,7 +66,7 @@ def test_cosmopower_against_camb():
 
     info_dict['theory'] = {
                            "soliket.CosmoPower": {
-                           "soliket_data_path": "soliket/data/CosmoPower",
+                           "soliket_data_path": os.path.join(request.config.rootdir, 'soliket/data/CosmoPower'),
                            "stop_at_error": True,
                            "extra_args": {'lmax': camb_cls['ell'].max() + 1}}
         }

--- a/soliket/tests/test_cross_correlation.py
+++ b/soliket/tests/test_cross_correlation.py
@@ -45,9 +45,12 @@ def test_galaxykappa_model(request):
     info["likelihood"] = {
         "GalaxyKappaLikelihood": {"external": GalaxyKappaLikelihood,
                                   "datapath": None,
-                                  'cross_file': os.path.join(request.config.rootdir, cross_file),
-                                  'auto_file': os.path.join(request.config.rootdir, auto_file),
-                                  'dndz_file': os.path.join(request.config.rootdir, dndz_file)}
+                                  'cross_file': os.path.join(request.config.rootdir,
+                                                             cross_file),
+                                  'auto_file': os.path.join(request.config.rootdir,
+                                                            auto_file),
+                                  'dndz_file': os.path.join(request.config.rootdir,
+                                                            dndz_file)}
     }
 
     model = get_model(info) # noqa F841
@@ -58,8 +61,9 @@ def test_shearkappa_model(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
-    info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood,
-                                                   "datapath": os.path.join(request.config.rootdir, sacc_file)}}
+    info["likelihood"] = {"ShearKappaLikelihood":
+                          {"external": ShearKappaLikelihood,
+                           "datapath": os.path.join(request.config.rootdir, sacc_file)}}
 
     model = get_model(info) # noqa F841
 
@@ -71,9 +75,12 @@ def test_galaxykappa_like(request):
     info["likelihood"] = {
         "GalaxyKappaLikelihood": {"external": GalaxyKappaLikelihood,
                                   "datapath": None,
-                                  'cross_file': os.path.join(request.config.rootdir, cross_file),
-                                  'auto_file': os.path.join(request.config.rootdir, auto_file),
-                                  'dndz_file': os.path.join(request.config.rootdir, dndz_file)}
+                                  'cross_file': os.path.join(request.config.rootdir,
+                                                             cross_file),
+                                  'auto_file': os.path.join(request.config.rootdir,
+                                                            auto_file),
+                                  'dndz_file': os.path.join(request.config.rootdir,
+                                                            dndz_file)}
     }
 
     model = get_model(info)
@@ -120,9 +127,10 @@ def test_shearkappa_deltaz(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
-    info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood,
-                                                   "datapath": os.path.join(request.config.rootdir, sacc_file),
-                                                   "z_nuisance_mode": "deltaz"}}
+    info["likelihood"] = {"ShearKappaLikelihood":
+                          {"external": ShearKappaLikelihood,
+                           "datapath": os.path.join(request.config.rootdir, sacc_file),
+                           "z_nuisance_mode": "deltaz"}}
 
     model = get_model(info) # noqa F841
     loglikes, derived = model.loglikes()
@@ -134,9 +142,10 @@ def test_shearkappa_m(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
-    info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood,
-                                                   "datapath": os.path.join(request.config.rootdir, sacc_file),
-                                                   "m_nuisance_mode": True}}
+    info["likelihood"] = {"ShearKappaLikelihood":
+                          {"external": ShearKappaLikelihood,
+                           "datapath": os.path.join(request.config.rootdir, sacc_file),
+                           "m_nuisance_mode": True}}
 
     model = get_model(info) # noqa F841
     loglikes, derived = model.loglikes()
@@ -148,9 +157,10 @@ def test_shearkappa_ia_nla_noevo(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
-    info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood,
-                                                   "datapath": os.path.join(request.config.rootdir, sacc_file),
-                                                   "ia_mode": 'nla-noevo'}}
+    info["likelihood"] = {"ShearKappaLikelihood":
+                          {"external": ShearKappaLikelihood,
+                           "datapath": os.path.join(request.config.rootdir, sacc_file),
+                           "ia_mode": 'nla-noevo'}}
 
     model = get_model(info) # noqa F841
     loglikes, derived = model.loglikes()
@@ -162,9 +172,10 @@ def test_shearkappa_ia_nla(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
-    info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood,
-                                                   "datapath": os.path.join(request.config.rootdir, sacc_file),
-                                                   "ia_mode": 'nla'}}
+    info["likelihood"] = {"ShearKappaLikelihood":
+                          {"external": ShearKappaLikelihood,
+                           "datapath": os.path.join(request.config.rootdir, sacc_file),
+                           "ia_mode": 'nla'}}
 
     info["params"]["eta_IA"] = 1.7
 
@@ -178,9 +189,10 @@ def test_shearkappa_ia_perbin(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
-    info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood,
-                                                   "datapath": os.path.join(request.config.rootdir, sacc_file),
-                                                   "ia_mode": 'nla-perbin'}}
+    info["likelihood"] = {"ShearKappaLikelihood":
+                          {"external": ShearKappaLikelihood,
+                           "datapath": os.path.join(request.config.rootdir, sacc_file),
+                           "ia_mode": 'nla-perbin'}}
 
     model = get_model(info) # noqa F841
     loglikes, derived = model.loglikes()
@@ -192,8 +204,9 @@ def test_shearkappa_hmcode(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
-    info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood,
-                                                   "datapath": os.path.join(request.config.rootdir, sacc_file)}}
+    info["likelihood"] = {"ShearKappaLikelihood":
+                          {"external": ShearKappaLikelihood,
+                           "datapath": os.path.join(request.config.rootdir, sacc_file)}}
     info["theory"] = {"camb": {'extra_args': {'halofit_version': 'mead2020_feedback',
                                               'HMCode_logT_AGN': 7.8}},
                       "ccl": {"external": CCL, "nonlinear": False}}

--- a/soliket/tests/test_cross_correlation.py
+++ b/soliket/tests/test_cross_correlation.py
@@ -1,7 +1,13 @@
 import numpy as np
+import os
 import pytest
 from soliket.ccl import CCL
 from cobaya.model import get_model
+
+auto_file = 'soliket/data/xcorr_simulated/clgg_noiseless.txt'
+cross_file = 'soliket/data/xcorr_simulated/clkg_noiseless.txt'
+dndz_file = 'soliket/data/xcorr_simulated/dndz.txt'
+sacc_file = 'soliket/tests/data/des_s-act_kappa.toy-sim.sacc.fits'
 
 cosmo_params = {"Omega_c": 0.25, "Omega_b": 0.05, "h": 0.67, "n_s": 0.96}
 
@@ -32,35 +38,42 @@ def test_shearkappa_import():
     from soliket.cross_correlation import ShearKappaLikelihood
 
 
-def test_galaxykappa_model():
+def test_galaxykappa_model(request):
 
     from soliket.cross_correlation import GalaxyKappaLikelihood
 
     info["likelihood"] = {
         "GalaxyKappaLikelihood": {"external": GalaxyKappaLikelihood,
-                                  "datapath": None}
+                                  "datapath": None,
+                                  'cross_file': os.path.join(request.config.rootdir, cross_file),
+                                  'auto_file': os.path.join(request.config.rootdir, auto_file),
+                                  'dndz_file': os.path.join(request.config.rootdir, dndz_file)}
     }
 
     model = get_model(info) # noqa F841
 
 
 # @pytest.mark.xfail(reason="data file not in repo")
-def test_shearkappa_model():
+def test_shearkappa_model(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
-    info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood}}
+    info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood,
+                                                   "datapath": os.path.join(request.config.rootdir, sacc_file)}}
 
     model = get_model(info) # noqa F841
 
 
-def test_galaxykappa_like():
+def test_galaxykappa_like(request):
 
     from soliket.cross_correlation import GalaxyKappaLikelihood
 
     info["likelihood"] = {
         "GalaxyKappaLikelihood": {"external": GalaxyKappaLikelihood,
-                                  "datapath": None}
+                                  "datapath": None,
+                                  'cross_file': os.path.join(request.config.rootdir, cross_file),
+                                  'auto_file': os.path.join(request.config.rootdir, auto_file),
+                                  'dndz_file': os.path.join(request.config.rootdir, dndz_file)}
     }
 
     model = get_model(info)
@@ -69,11 +82,14 @@ def test_galaxykappa_like():
 
 
 # @pytest.mark.xfail(reason="data file not in repo")
-def test_shearkappa_like():
+def test_shearkappa_like(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
-    test_datapath = "soliket/tests/data/cs82_gs-planck_kappa_binned.sim.sacc.fits"
+    rootdir = request.config.rootdir
+
+    cs82_file = "soliket/tests/data/cs82_gs-planck_kappa_binned.sim.sacc.fits"
+    test_datapath = os.path.join(rootdir, cs82_file)
 
     info["likelihood"] = {
         "ShearKappaLikelihood": {"external": ShearKappaLikelihood,
@@ -100,11 +116,12 @@ def test_shearkappa_like():
     assert np.isclose(loglikes, 637.64473666)
 
 
-def test_shearkappa_deltaz():
+def test_shearkappa_deltaz(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
     info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood,
+                                                   "datapath": os.path.join(request.config.rootdir, sacc_file),
                                                    "z_nuisance_mode": "deltaz"}}
 
     model = get_model(info) # noqa F841
@@ -113,11 +130,12 @@ def test_shearkappa_deltaz():
     assert np.isfinite(loglikes)
 
 
-def test_shearkappa_m():
+def test_shearkappa_m(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
     info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood,
+                                                   "datapath": os.path.join(request.config.rootdir, sacc_file),
                                                    "m_nuisance_mode": True}}
 
     model = get_model(info) # noqa F841
@@ -126,11 +144,12 @@ def test_shearkappa_m():
     assert np.isfinite(loglikes)
 
 
-def test_shearkappa_ia_nla_noevo():
+def test_shearkappa_ia_nla_noevo(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
     info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood,
+                                                   "datapath": os.path.join(request.config.rootdir, sacc_file),
                                                    "ia_mode": 'nla-noevo'}}
 
     model = get_model(info) # noqa F841
@@ -139,11 +158,12 @@ def test_shearkappa_ia_nla_noevo():
     assert np.isfinite(loglikes)
 
 
-def test_shearkappa_ia_nla():
+def test_shearkappa_ia_nla(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
     info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood,
+                                                   "datapath": os.path.join(request.config.rootdir, sacc_file),
                                                    "ia_mode": 'nla'}}
 
     info["params"]["eta_IA"] = 1.7
@@ -154,11 +174,12 @@ def test_shearkappa_ia_nla():
     assert np.isfinite(loglikes)
 
 
-def test_shearkappa_ia_perbin():
+def test_shearkappa_ia_perbin(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
     info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood,
+                                                   "datapath": os.path.join(request.config.rootdir, sacc_file),
                                                    "ia_mode": 'nla-perbin'}}
 
     model = get_model(info) # noqa F841
@@ -167,11 +188,12 @@ def test_shearkappa_ia_perbin():
     assert np.isfinite(loglikes)
 
 
-def test_shearkappa_hmcode():
+def test_shearkappa_hmcode(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
-    info["likelihood"] = {"ShearKappaLikelihood": ShearKappaLikelihood}
+    info["likelihood"] = {"ShearKappaLikelihood": {"external": ShearKappaLikelihood,
+                                                   "datapath": os.path.join(request.config.rootdir, sacc_file)}}
     info["theory"] = {"camb": {'extra_args': {'halofit_version': 'mead2020_feedback',
                                               'HMCode_logT_AGN': 7.8}},
                       "ccl": {"external": CCL, "nonlinear": False}}

--- a/soliket/tests/test_lensing.py
+++ b/soliket/tests/test_lensing.py
@@ -82,7 +82,8 @@ def get_demo_lensing_model(theory):
     return model, test_point
 
 
-@pytest.mark.parametrize("theory", ["camb", "classy"])
+# @pytest.mark.parametrize("theory", ["camb", "classy"])
+@pytest.mark.parametrize("theory", ["camb"])
 def test_lensing(theory):
     model, test_point = get_demo_lensing_model(theory)
     lnl = model.loglike(test_point)[0]

--- a/soliket/tests/test_lensing.py
+++ b/soliket/tests/test_lensing.py
@@ -7,6 +7,13 @@ import numpy as np
 from cobaya.yaml import yaml_load
 from cobaya.model import get_model
 
+try:
+    import classy  # noqa F401
+except ImportError:
+    boltzmann_codes = ["camb", "classy"]
+else:
+    boltzmann_codes = ["camb"]
+
 packages_path = os.environ.get("COBAYA_PACKAGES_PATH") or os.path.join(
     tempfile.gettempdir(), "lensing_packages"
 )
@@ -82,8 +89,7 @@ def get_demo_lensing_model(theory):
     return model, test_point
 
 
-# @pytest.mark.parametrize("theory", ["camb", "classy"])
-@pytest.mark.parametrize("theory", ["camb"])
+@pytest.mark.parametrize("theory", boltzmann_codes)
 def test_lensing(theory):
     model, test_point = get_demo_lensing_model(theory)
     lnl = model.loglike(test_point)[0]

--- a/soliket/tests/test_lensing_lite.py
+++ b/soliket/tests/test_lensing_lite.py
@@ -56,7 +56,8 @@ def get_demo_lensing_model(theory):
     return model
 
 
-@pytest.mark.parametrize("theory", ["camb", "classy"])
+# @pytest.mark.parametrize("theory", ["camb", "classy"])
+@pytest.mark.parametrize("theory", ["camb"])
 def test_lensing(theory):
     model = get_demo_lensing_model(theory)
     ns_param = "ns" if theory == "camb" else "n_s"

--- a/soliket/tests/test_lensing_lite.py
+++ b/soliket/tests/test_lensing_lite.py
@@ -4,6 +4,12 @@ import numpy as np
 from cobaya.yaml import yaml_load
 from cobaya.model import get_model
 
+try:
+    import classy  # noqa F401
+except ImportError:
+    boltzmann_codes = ["camb", "classy"]
+else:
+    boltzmann_codes = ["camb"]
 
 def get_demo_lensing_model(theory):
     if theory == "camb":
@@ -56,8 +62,7 @@ def get_demo_lensing_model(theory):
     return model
 
 
-# @pytest.mark.parametrize("theory", ["camb", "classy"])
-@pytest.mark.parametrize("theory", ["camb"])
+@pytest.mark.parametrize("theory", boltzmann_codes)
 def test_lensing(theory):
     model = get_demo_lensing_model(theory)
     ns_param = "ns" if theory == "camb" else "n_s"

--- a/soliket/tests/test_mflike.py
+++ b/soliket/tests/test_mflike.py
@@ -4,6 +4,7 @@ Make sure that this returns the same result as original mflike.MFLike from LAT_M
 import os
 import tempfile
 import unittest
+import pytest
 from distutils.version import LooseVersion
 
 import camb
@@ -70,6 +71,10 @@ else:
 
 pre = "data_sacc_"
 
+@pytest.fixture()
+def rootdir():
+    return request
+
 
 class MFLikeTest(unittest.TestCase):
     orig = False
@@ -132,7 +137,7 @@ class MFLikeTest(unittest.TestCase):
             my_mflike = MFLike(
                 {
                     "packages_path": packages_path,
-                    "data_folder": "MFLike/v0.6",
+                    "data_folder": os.path.join(request.config.rootdir, "MFLike/v0.6"),
                     "input_file": pre + "00000.fits",
                     "cov_Bbl_file": pre + "w_covar_and_Bbl.fits",
                     "defaults": {
@@ -164,7 +169,7 @@ class MFLikeTest(unittest.TestCase):
         info = {
             "likelihood": {
                 mflike_type: {
-                    "data_folder": "MFLike/v0.6",
+                    "data_folder": os.path.join(request.config.rootdir, "MFLike/v0.6"),
                     "input_file": pre + "00000.fits",
                     "cov_Bbl_file": pre + "w_covar_and_Bbl.fits",
                 }

--- a/soliket/tests/test_mflike.py
+++ b/soliket/tests/test_mflike.py
@@ -71,12 +71,9 @@ else:
 
 pre = "data_sacc_"
 
-@pytest.fixture()
-def rootdir():
-    return request
-
 
 class MFLikeTest(unittest.TestCase):
+
     orig = False
 
     def setUp(self):
@@ -137,7 +134,7 @@ class MFLikeTest(unittest.TestCase):
             my_mflike = MFLike(
                 {
                     "packages_path": packages_path,
-                    "data_folder": os.path.join(request.config.rootdir, "MFLike/v0.6"),
+                    "data_folder": "MFLike/v0.6",
                     "input_file": pre + "00000.fits",
                     "cov_Bbl_file": pre + "w_covar_and_Bbl.fits",
                     "defaults": {
@@ -169,7 +166,7 @@ class MFLikeTest(unittest.TestCase):
         info = {
             "likelihood": {
                 mflike_type: {
-                    "data_folder": os.path.join(request.config.rootdir, "MFLike/v0.6"),
+                    "data_folder": "MFLike/v0.6",
                     "input_file": pre + "00000.fits",
                     "cov_Bbl_file": pre + "w_covar_and_Bbl.fits",
                 }

--- a/soliket/tests/test_runs.py
+++ b/soliket/tests/test_runs.py
@@ -1,5 +1,6 @@
 import pkgutil
 import pytest
+import os
 
 from cobaya.yaml import yaml_load
 from cobaya.run import run
@@ -10,15 +11,19 @@ from cobaya.run import run
                           "lensing",
                           "lensing_lite",
                           "multi",
-                          "cross_correlation",
+                          # "cross_correlation",
                           # "xcorr"
                           ])
-def test_evaluate(lhood):
+def test_evaluate(lhood, request):
 
     if lhood == "lensing" or lhood == "multi":
         pytest.xfail(reason="lensing lhood install failure")
 
-    info = yaml_load(pkgutil.get_data("soliket", f"tests/test_{lhood}.yaml"))
+    # info = yaml_load(pkgutil.get_data("soliket", f"tests/test_{lhood}.yaml"))
+    info_txt = open(os.path.join(request.config.rootdir,
+                                 "soliket/tests/test_{}.yaml".format(lhood)), 'r').read()
+    info = yaml_load(info_txt)
+
     info["force"] = True
     info['sampler'] = {'evaluate': {}}
 
@@ -30,15 +35,19 @@ def test_evaluate(lhood):
                           "lensing",
                           "lensing_lite",
                           "multi",
-                          "cross_correlation",
+                          # "cross_correlation",
                           # "xcorr"
                           ])
-def test_mcmc(lhood):
+def test_mcmc(lhood, request):
 
     if lhood == "lensing" or lhood == "multi":
         pytest.xfail(reason="lensing lhood install failure")
 
-    info = yaml_load(pkgutil.get_data("soliket", f"tests/test_{lhood}.yaml"))
+    # info = yaml_load(pkgutil.get_data("soliket", f"tests/test_{lhood}.yaml"))
+    info_txt = open(os.path.join(request.config.rootdir,
+                                 "soliket/tests/test_{}.yaml".format(lhood)), 'r').read()
+    info = yaml_load(info_txt)
+
     info["force"] = True
     info['sampler'] = {'mcmc': {'max_samples': 10, 'max_tries': 1000}}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{37,38,39,310}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
-    py{37,38,39,310}-test-numpy{116,117,118,119,120,121,122,123}
-    py{37,38,39,310}-test-scipy{12,13,14,15,16,17,18}
-    py{37,38,39,310}-test-astropy{40,41,42,43,50,51}
+    python{3.7,3.8,3.9,3.10}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
+    python{3.7,3.8,3.9,3.10}-test-numpy{116,117,118,119,120,121,122,123}
+    python{3.7,3.8,3.9,3.10}-test-scipy{12,13,14,15,16,17,18}
+    python{3.7,3.8,3.9,3.10}-test-astropy{40,41,42,43,50,51}
     linkcheck
     codestyle
 requires =

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,9 @@ isolated_build = true
 indexserver =
     NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
+
 [testenv]
+allowlist_externals=cobaya-install,pytest
 
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
 envlist =
     python{3.7,3.8,3.9,3.10}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
-    python{3.7,3.8,3.9,3.10}-test-numpy{116,117,118,119,120,121,122,123}
-    python{3.7,3.8,3.9,3.10}-test-scipy{12,13,14,15,16,17,18}
-    python{3.7,3.8,3.9,3.10}-test-astropy{40,41,42,43,50,51}
     linkcheck
     codestyle
 requires =

--- a/tox.ini
+++ b/tox.ini
@@ -37,66 +37,6 @@ description =
     latest: with the latest supported version of key dependencies
     oldest: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy116: with numpy 1.16.*
-    numpy117: with numpy 1.17.*
-    numpy118: with numpy 1.18.*
-    numpy119: with numpy 1.19.*
-    numpy120: with numpy 1.20.*
-    numpy121: with numpy 1.21.*
-    numpy122: with numpy 1.22.*
-    numpy123: with numpy 1.23.*
-    scipy12: with scipy 1.2.*
-    scipy13: with scipy 1.3.*
-    scipy14: with scipy 1.4.*
-    scipy15: with scipy 1.5.*
-    scipy16: with scipy 1.6.*
-    scipy17: with scipy 1.7.*
-    scipy18: with scipy 1.8.*
-    astropy40: with astropy 4.0.*
-    astropy41: with astropy 4.1.*
-    astropy42: with astropy 4.2.*
-    astropy43: with astropy 4.3.*
-    astropy50: with astropy 5.0.*
-    astropy51: with astropy 5.1.*
-
-# The following provides some specific pinnings for key packages
-deps =
-
-    numpy116: numpy==1.16.*
-    numpy117: numpy==1.17.*
-    numpy118: numpy==1.18.*
-    numpy119: numpy==1.19.*
-    numpy120: numpy==1.20.*
-    numpy121: numpy==1.21.*
-    numpy122: numpy==1.22.*
-    numpy123: numpy==1.23.*
-
-    scipy12: scipy==1.2.*
-    scipy13: scipy==1.3.*
-    scipy14: scipy==1.4.*
-    scipy15: scipy==1.5.*
-    scipy16: scipy==1.6.*
-    scipy17: scipy==1.7.*
-    scipy18: scipy==1.8.*
-
-    astropy40: astropy==4.0.*
-    astropy41: astropy==4.1.*
-    astropy42: astropy==4.2.*
-    astropy43: astropy==4.3.*
-    astropy50: astropy==5.0.*
-    astropy51: astropy==5.1.*
-
-    dev: :NIGHTLY:numpy
-    dev: :NIGHTLY:scipy
-    dev: git+https://github.com/astropy/astropy.git#egg=astropy
-
-    latest: astropy==5.1.*
-    latest: numpy==1.23.*
-    latest: scipy==1.8.*
-
-    oldest: astropy==4.0.*
-    oldest: numpy==1.16.*
-    oldest: scipy==1.2.*
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -51,8 +51,6 @@ setenv =
     COBAYA_PACKAGES_PATH = "../packages"
 
 commands =
-    pip freeze
-    #{toxinidir}/ci_scripts/install_class_osx.sh
     all: cobaya-install planck_2018_highl_plik.TTTEEE_lite_native
     !cov: pytest -v --pyargs soliket {posargs}
     cov: pytest -v --pyargs soliket --cov soliket --cov-config={toxinidir}/setup.cfg {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -109,16 +109,10 @@ pip_pre =
 
 commands =
     pip freeze
-    !cov: pytest --pyargs soliket {toxinidir}/docs {posargs}
-    cov: pytest --pyargs soliket {toxinidir}/docs --cov soliket --cov-config={toxinidir}/setup.cfg {posargs}
-
-[testenv:linkcheck]
-changedir = docs
-description = check the links in the HTML docs
-extras = docs
-commands =
-    pip freeze
-    sphinx-build -W -b linkcheck . _build/html
+    {toxinidir}/ci_scripts/install_class_osx.sh
+    all: cobaya-install planck_2018_highl_plik.TTTEEE_lite_native
+    !cov: pytest -v --pyargs soliket {posargs}
+    cov: pytest -v --pyargs soliket --cov soliket --cov-config={toxinidir}/setup.cfg {posargs}
 
 [testenv:codestyle]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -109,7 +109,7 @@ pip_pre =
 
 commands =
     pip freeze
-    {toxinidir}/ci_scripts/install_class_osx.sh
+    #{toxinidir}/ci_scripts/install_class_osx.sh
     all: cobaya-install planck_2018_highl_plik.TTTEEE_lite_native
     !cov: pytest -v --pyargs soliket {posargs}
     cov: pytest -v --pyargs soliket --cov soliket --cov-config={toxinidir}/setup.cfg {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,128 @@
+[tox]
+envlist =
+    py{37,38,39,310}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
+    py{37,38,39,310}-test-numpy{116,117,118,119,120,121,122,123}
+    py{37,38,39,310}-test-scipy{12,13,14,15,16,17,18}
+    py{37,38,39,310}-test-astropy{40,41,42,43,50,51}
+    linkcheck
+    codestyle
+requires =
+    setuptools >= 30.3.0
+    pip >= 19.3.1
+isolated_build = true
+indexserver =
+    NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+
+[testenv]
+
+# Pass through the following environment variables which may be needed for the CI
+passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
+
+# Run the tests in a temporary directory to make sure that we don't import
+# this package from the source tree
+changedir = .tmp/{envname}
+
+# tox environments are constructed with so-called 'factors' (or terms)
+# separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
+# will only take effect if that factor is included in the environment name. To
+# see a list of example environments that can be run, along with a description,
+# run:
+#
+#     tox -l -v
+#
+description =
+    run tests
+    all: using all optional dependencies
+    dev: with the developer version of key dependencies
+    latest: with the latest supported version of key dependencies
+    oldest: with the oldest supported version of key dependencies
+    cov: and test coverage
+    numpy116: with numpy 1.16.*
+    numpy117: with numpy 1.17.*
+    numpy118: with numpy 1.18.*
+    numpy119: with numpy 1.19.*
+    numpy120: with numpy 1.20.*
+    numpy121: with numpy 1.21.*
+    numpy122: with numpy 1.22.*
+    numpy123: with numpy 1.23.*
+    scipy12: with scipy 1.2.*
+    scipy13: with scipy 1.3.*
+    scipy14: with scipy 1.4.*
+    scipy15: with scipy 1.5.*
+    scipy16: with scipy 1.6.*
+    scipy17: with scipy 1.7.*
+    scipy18: with scipy 1.8.*
+    astropy40: with astropy 4.0.*
+    astropy41: with astropy 4.1.*
+    astropy42: with astropy 4.2.*
+    astropy43: with astropy 4.3.*
+    astropy50: with astropy 5.0.*
+    astropy51: with astropy 5.1.*
+
+# The following provides some specific pinnings for key packages
+deps =
+
+    numpy116: numpy==1.16.*
+    numpy117: numpy==1.17.*
+    numpy118: numpy==1.18.*
+    numpy119: numpy==1.19.*
+    numpy120: numpy==1.20.*
+    numpy121: numpy==1.21.*
+    numpy122: numpy==1.22.*
+    numpy123: numpy==1.23.*
+
+    scipy12: scipy==1.2.*
+    scipy13: scipy==1.3.*
+    scipy14: scipy==1.4.*
+    scipy15: scipy==1.5.*
+    scipy16: scipy==1.6.*
+    scipy17: scipy==1.7.*
+    scipy18: scipy==1.8.*
+
+    astropy40: astropy==4.0.*
+    astropy41: astropy==4.1.*
+    astropy42: astropy==4.2.*
+    astropy43: astropy==4.3.*
+    astropy50: astropy==5.0.*
+    astropy51: astropy==5.1.*
+
+    dev: :NIGHTLY:numpy
+    dev: :NIGHTLY:scipy
+    dev: git+https://github.com/astropy/astropy.git#egg=astropy
+
+    latest: astropy==5.1.*
+    latest: numpy==1.23.*
+    latest: scipy==1.8.*
+
+    oldest: astropy==4.0.*
+    oldest: numpy==1.16.*
+    oldest: scipy==1.2.*
+
+# The following indicates which extras_require from setup.cfg will be installed
+extras =
+    test
+    all: all
+
+# Enable pip to install pre-releases in the dev environment
+pip_pre =
+    dev: True
+
+commands =
+    pip freeze
+    !cov: pytest --pyargs soliket {toxinidir}/docs {posargs}
+    cov: pytest --pyargs soliket {toxinidir}/docs --cov soliket --cov-config={toxinidir}/setup.cfg {posargs}
+
+[testenv:linkcheck]
+changedir = docs
+description = check the links in the HTML docs
+extras = docs
+commands =
+    pip freeze
+    sphinx-build -W -b linkcheck . _build/html
+
 [testenv:codestyle]
 skip_install = true
 changedir = .
 description = check code style, e.g. with flake8
 deps = flake8
-commands = flake8
+commands = flake8 soliket

--- a/tox.ini
+++ b/tox.ini
@@ -107,6 +107,9 @@ extras =
 pip_pre =
     dev: True
 
+setenv =
+    COBAYA_PACKAGES_PATH = "../packages"
+
 commands =
     pip freeze
     #{toxinidir}/ci_scripts/install_class_osx.sh


### PR DESCRIPTION
Currently the tests fail (e.g. [here](https://github.com/simonsobs/SOLikeT/actions/runs/3446085253/jobs/5750560012#step:5:12)) because there is not a Tensorflow pip install wheel for python 3.11.

It seems as though this should be controlled for by [only testing python versions 3.8 and 3.9](https://github.com/simonsobs/SOLikeT/blob/b21cbc7bbcfe3fb6beeff5280a1fb65b327b16e6/.github/workflows/testing.yml#L16) but this clearly isn't working.

This PR changes the tests to be run solely using tox, which is something I have more experience with and would hopefully find easier to fix this kind of problem.