### PR TITLE
Removed cosmopower installation, test now skipped

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,11 +29,6 @@ jobs:
       run: |
         conda install pip compilers pytest pytest-cov pyccl cython
         pip install cobaya
-
-    - name: install extra reqs
-      run: |
-        pip install cosmopower
-
       env:  
         MATRIX_OS: ${{ matrix.os }}
 


### PR DESCRIPTION
In order to address #86 more quickly so that we can run tests and continue dev work, this just removes the installation of cosmopower from the test env, meaning that the cosmopower tests are skipped when the CI is run.