### PR TITLE
Allow more flexible CosmoPower network settings.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     mflike @ git+https://github.com/simonsobs/lat_mflike@master
 
 [options.package_data]
-soliket = *.yaml,*.bibtex,clusters/data/*,clusters/data/selFn_equD56/*,lensing/data/*.txt,mflike/*.yaml,tests/*.yaml,data/xcorr_simulated/*.txt
+soliket = *.yaml,*.bibtex,clusters/data/*,clusters/data/selFn_equD56/*,lensing/data/*.txt,mflike/*.yaml,tests/*.yaml,data/xcorr_simulated/*.txt,data/CosmoPower/CP_paper/CMB/*.pkl
 testpaths = "soliket"
 text_file_format = rst
 

--- a/soliket/__init__.py
+++ b/soliket/__init__.py
@@ -7,7 +7,7 @@ from .mflike import TheoryForge_MFLike
 from .xcorr import XcorrLikelihood  # noqa: F401
 from .foreground import Foreground
 from .bandpass import BandPass
-from .cosmopower import CosmoPower
+from .cosmopower import CosmoPower, CosmoPowerDerived
 
 try:
     from .clusters import ClusterLikelihood  # noqa: F401

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -128,7 +128,7 @@ class CosmoPower(BoltzmannBase):
             if self.networks[k]["has_ell_factor"]:
                 cl_fac = (2.0 * np.pi) / (ls * (ls + 1.0))
 
-            cls[k][ls] = cls_old[k] * ls_fac * cmb_fac ** 2.0
+            cls[k][ls] = cls_old[k] * cl_fac * ls_fac * cmb_fac ** 2.0
             if np.any(np.isnan(cls[k])):
                 self.log.warning("CosmoPower used outside of trained "\
                                  "{} ell range. Filled in with NaNs.".format(k))

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -1,3 +1,29 @@
+"""
+.. module:: soliket.cosmopower
+
+:Synopsis: Simple CosmoPower theory wrapper for Cobaya.
+:Author: Hidde T. Jense
+
+.. |br| raw:: html
+   
+   <br />
+
+.. note::
+   
+   **If you use this cosmological code, please cite:**
+   |br|
+   A. Spurio Mancini et al.
+   *CosmoPower: emulating cosmological power spectra for accelerated Bayesian inference from next-generation surveys*
+   (`arXiv:210603846 <https://arxiv.org/abs/2106.03846>`_)
+   
+   And remember to cite any sources for trained networks you use.
+
+Usage
+-----
+
+After installing SOLikeT, you can use the ``CosmoPower`` theory codes by adding the ``soliket.CosmoPower`` code as a block in your parameter files.
+
+"""
 import os
 try:
     import cosmopower as cp  # noqa F401
@@ -14,17 +40,9 @@ from cobaya.theory import Theory
 from cobaya.theories.cosmo import BoltzmannBase
 from cobaya.typing import InfoDict
 
-"""
-Simple CosmoPower theory wrapper for Cobaya.
-
-author: Hidde T. Jense
-"""
-
 
 class CosmoPower(BoltzmannBase):
-    """
-    A CosmoPower Network wrapper for Cobaya.
-    """
+    """A CosmoPower Network wrapper for Cobaya."""
 
     stop_at_error: bool = False
 
@@ -142,19 +160,17 @@ class CosmoPower(BoltzmannBase):
         These prefactors are used to convert from Cell to Dell and vice-versa.
 
         See also:
-          cobaya.BoltzmannBase.get_Cl
-          camb.CAMBresults.get_cmb_power_spectra
-
-        Keyword arguments:
-          ls -- the range of ells.
-          spectra -- a two-character string with each character being one of [tebp].
-
-        Return:
-          ellfac -- an array filled with ell factors for the given spectrum.
+        cobaya.BoltzmannBase.get_Cl
+        `camb.CAMBresults.get_cmb_power_spectra <https://camb.readthedocs.io/en/latest/results.html#camb.results.CAMBdata.get_cmb_power_spectra>`_
 
         Example:
-          ell_factor(l, "tt") -> l(l+1)/(2 pi).
-          ell_factor(l, "pp") -> l^2(l+1)^2/(2 pi).
+        ell_factor(l, "tt") -> l(l+1)/(2 pi).
+        ell_factor(l, "pp") -> l^2(l+1)^2/(2 pi).
+
+        :param ls: the range of ells.
+        :param spectra: a two-character string with each character being one of [tebp].
+
+        :return: an array filled with ell factors for the given spectrum.
         """
         ellfac = np.ones_like(ls).astype(float)
 
@@ -171,13 +187,10 @@ class CosmoPower(BoltzmannBase):
         """
         Calculate the CMB prefactor for going from dimensionless power spectra to CMB units.
 
-        Keyword arguments:
-          spectra -- a length 2 string specifying the spectrum for which to calculate the units.
-          units -- a string specifying which units to use.
-          Tcmb -- the used CMB temperature [units of K].
-
-        Return:
-          The CMB unit factor.
+        :param spectra: a length 2 string specifying the spectrum for which to calculate the units.
+        :param units: a string specifying which units to use.
+        :param Tcmb: the used CMB temperature [units of K].
+        :return: The CMB unit conversion factor.
         """
         res = 1.0
         x, y = spectra.lower()
@@ -212,9 +225,7 @@ class CosmoPower(BoltzmannBase):
 
 
 class CosmoPowerDerived(Theory):
-    """
-    A theory class that can calculate derived parameters from CosmoPower networks.
-    """
+    """A theory class that can calculate derived parameters from CosmoPower networks."""
     stop_at_error: bool = False
 
     soliket_data_path: str = "soliket/data/CosmoPower"

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -22,7 +22,6 @@ Usage
 -----
 
 After installing SOLikeT, you can use the ``CosmoPower`` theory codes by adding the ``soliket.CosmoPower`` code as a block in your parameter files.
-
 """
 import os
 try:
@@ -46,16 +45,16 @@ class CosmoPower(BoltzmannBase):
 
     stop_at_error: bool = False
 
-    soliket_data_path: str = "soliket/data/CosmoPower"
-    network_path: str = "CP_paper/CMB"
-    network_settings: InfoDict = {}
+    network_path: str = "soliket/data/CosmoPower/CP_paper/CMB"
+    network_settings: InfoDict = None
 
     extra_args: InfoDict = None
 
     def initialize(self) -> None:
         super().initialize()
 
-        base_path = os.path.join(self.soliket_data_path, self.network_path)
+        if self.network_settings is None:
+            raise LoggedError("No network settings were provided.")
 
         self.networks = {}
         self.all_parameters = set([])
@@ -63,7 +62,7 @@ class CosmoPower(BoltzmannBase):
         for spectype in self.network_settings:
             netdata = {}
             nettype = self.network_settings[spectype]
-            netpath = os.path.join(base_path, nettype["filename"])
+            netpath = os.path.join(self.network_path, nettype["filename"])
 
             if nettype["type"] == "NN":
                 network = cp.cosmopower_NN(
@@ -228,9 +227,8 @@ class CosmoPowerDerived(Theory):
     """A theory class that can calculate derived parameters from CosmoPower networks."""
     stop_at_error: bool = False
 
-    soliket_data_path: str = "soliket/data/CosmoPower"
-    network_path: str = "CP_paper/CMB"
-    network_settings: InfoDict = {}
+    network_path: str = "soliket/data/CosmoPower/CP_paper/CMB"
+    network_settings: InfoDict = None
 
     derived_parameters: Iterable[str]
     derived_values: Dict
@@ -242,8 +240,10 @@ class CosmoPowerDerived(Theory):
     def initialize(self) -> None:
         super().initialize()
 
-        base_path = os.path.join(self.soliket_data_path, self.network_path)
-        netpath = os.path.join(base_path, self.network_settings["filename"])
+        if self.network_settings is None:
+            raise LoggedError("No network settings were provided.")
+
+        netpath = os.path.join(self.network_path, self.network_settings["filename"])
 
         if self.network_settings["type"] == "NN":
             self.network = cp.cosmopower_NN(

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -89,12 +89,12 @@ class CosmoPower(BoltzmannBase):
 
         for spectype in self.networks:
             network = self.networks[spectype]
-            used_params = { par : cmb_params[par] for par in cmb_params if par in network["parameters"] }
+            used_params = { par : (cmb_params[par] if par in cmb_params else [params[par]]) for par in network["parameters"] }
 
             if network["log"]:
-                data = network["network"].ten_to_predictions_np(cmb_params)[0, :]
+                data = network["network"].ten_to_predictions_np(used_params)[0, :]
             else:
-                data = network["network"].predictions_np(cmb_params)[0, :]
+                data = network["network"].predictions_np(used_params)[0, :]
 
             state[spectype] = data
 

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -112,11 +112,7 @@ class CosmoPower(BoltzmannBase):
         ls = cls_old["ell"]
 
         for k in self.networks:
-            # cls[k] = np.zeros(cls["ell"].shape, dtype=float)
-            cls[k] = np.empty(cls["ell"].shape, dtype=float)
-            cls[k][:] = np.nan
-
-        cmb_fac = self._cmb_unit_factor(units, 2.7255)
+            cls[k] = np.tile(np.nan, cls["ell"].shape)
 
         if ell_factor:
             ls_fac = ls * (ls + 1.0) / (2.0 * np.pi)
@@ -124,16 +120,24 @@ class CosmoPower(BoltzmannBase):
             ls_fac = np.ones_like(ls)
 
         for k in self.networks:
+            cmb_fac = self.cmb_unit_factor(k, units, 2.7255)
             cl_fac = np.ones_like(ls_fac)
             if self.networks[k]["has_ell_factor"]:
                 cl_fac = (2.0 * np.pi) / (ls * (ls + 1.0))
 
             cls[k][ls] = cls_old[k] * cl_fac * ls_fac * cmb_fac ** 2.0
+            cls[k][:2] = 0.0
             if np.any(np.isnan(cls[k])):
                 self.log.warning("CosmoPower used outside of trained "\
                                  "{} ell range. Filled in with NaNs.".format(k))
 
         return cls
+
+    def cmb_unit_factor(self, spectra, units="FIRASmuK2", Tcmb=2.7255):
+        if spectra == "pp":
+            return 1./np.sqrt(2.0*np.pi)
+
+        return self._cmb_unit_factor(units, Tcmb)
 
     def get_can_support_params(self):
         return self.all_parameters

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -100,11 +100,17 @@ class CosmoPower(BoltzmannBase):
             f"CosmoPower will expect the parameters {self.all_parameters}")
 
     def calculate(self, state: dict, want_derived: bool = True, **params) -> bool:
-        cmb_params = {
+        ## sadly, this syntax not valid until python 3.9
+        # cmb_params = {
+        #     p: [params[p]] for p in params
+        # } | {
+        #     self.translate_param(p): [params[p]] for p in params
+        # }
+        cmb_params = {**{
             p: [params[p]] for p in params
-        } | {
+        }, **{
             self.translate_param(p): [params[p]] for p in params
-        }
+        }}
 
         ells = None
 
@@ -278,11 +284,17 @@ class CosmoPowerDerived(Theory):
         return self.renames.get(p, p)
 
     def calculate(self, state: dict, want_derived: bool = True, **params) -> bool:
-        input_params = {
+        ## sadly, this syntax not valid until python 3.9
+        # input_params = {
+        #     p: [params[p]] for p in params
+        # } | {
+        #     self.translate_param(p): [params[p]] for p in params
+        # }
+        input_params = {**{
             p: [params[p]] for p in params
-        } | {
+        }, **{
             self.translate_param(p): [params[p]] for p in params
-        }
+        }}
 
         if self.log_data:
             data = self.network.ten_to_predictions_np(input_params)[0, :]

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -77,7 +77,8 @@ class CosmoPower(BoltzmannBase):
                     f"Unknown network type {nettype['type']} for network {spectype}.")
             else:
                 self.log.warn(
-                    f"Unknown network type {nettype['type']} for network {spectype}: skipped!")
+                    f"Unknown network type {nettype['type']}\
+                                                for network {spectype}: skipped!")
 
             netdata["type"] = nettype["type"]
             netdata["log"] = nettype.get("log", True)
@@ -162,7 +163,7 @@ class CosmoPower(BoltzmannBase):
 
         See also:
         cobaya.BoltzmannBase.get_Cl
-        `camb.CAMBresults.get_cmb_power_spectra <https://camb.readthedocs.io/en/latest/results.html#camb.results.CAMBdata.get_cmb_power_spectra>`_
+        `camb.CAMBresults.get_cmb_power_spectra <https://camb.readthedocs.io/en/latest/results.html#camb.results.CAMBdata.get_cmb_power_spectra>`_ # noqa E501
 
         Example:
         ell_factor(l, "tt") -> l(l+1)/(2 pi).
@@ -184,11 +185,15 @@ class CosmoPower(BoltzmannBase):
 
         return ellfac
 
-    def cmb_unit_factor(self, spectra: str, units: str = "FIRASmuK2", Tcmb: float = 2.7255) -> float:
+    def cmb_unit_factor(self, spectra: str,
+                        units: str = "FIRASmuK2",
+                        Tcmb: float = 2.7255) -> float:
         """
-        Calculate the CMB prefactor for going from dimensionless power spectra to CMB units.
+        Calculate the CMB prefactor for going from dimensionless power spectra to
+        CMB units.
 
-        :param spectra: a length 2 string specifying the spectrum for which to calculate the units.
+        :param spectra: a length 2 string specifying the spectrum for which to
+                        calculate the units.
         :param units: a string specifying which units to use.
         :param Tcmb: the used CMB temperature [units of K].
         :return: The CMB unit conversion factor.
@@ -266,7 +271,8 @@ class CosmoPowerDerived(Theory):
         self.log.info(
             f"CosmoPowerDerived will expect the parameters {self.input_parameters}")
         self.log.info(
-            f"CosmoPowerDerived can provide the following parameters: {self.get_can_provide()}.")
+            f"CosmoPowerDerived can provide the following parameters: \
+                                                            {self.get_can_provide()}.")
 
     def translate_param(self, p):
         return self.renames.get(p, p)
@@ -311,4 +317,5 @@ class CosmoPowerDerived(Theory):
         return requirements
 
     def get_can_provide(self) -> Iterable[str]:
-        return set([par for par in self.derived_parameters if (len(par) > 0 and not par == "_")])
+        return set([par for par in self.derived_parameters
+                                    if (len(par) > 0 and not par == "_")])

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -68,10 +68,15 @@ class CosmoPower(BoltzmannBase):
             if not network is None:
                 self.networks[ spectype.lower() ] = netdata
 
+        if "ln10^{10}A_s" in self.all_parameters:
+            self.all_parameters.remove("ln10^{10}A_s")
+            self.all_parameters.add("logA")
+
         if "lmax" not in self.extra_args:
             self.extra_args["lmax"] = None
 
         self.log.info(f"Loaded CosmoPower from directory {self.network_path}")
+        self.log.info(f"CosmoPower will expect the parameters {self.all_parameters}")
 
     def calculate(self, state, want_derived=True, **params):
         cmb_params = { }
@@ -153,5 +158,8 @@ class CosmoPower(BoltzmannBase):
 
         return res
 
-    def get_can_support_params(self):
+    def get_can_support_parameters(self):
+        return self.get_requirements()
+
+    def get_requirements(self):
         return self.all_parameters

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -22,8 +22,8 @@
 Usage
 -----
 
-After installing SOLikeT, you can use the ``CosmoPower`` theory codes by adding
-the ``soliket.CosmoPower`` code as a block in your parameter files.
+After installing SOLikeT and cosmopower, you can use the ``CosmoPower`` theory codes
+by adding the ``soliket.CosmoPower`` code as a block in your parameter files.
 """
 import os
 try:

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -5,23 +5,25 @@
 :Author: Hidde T. Jense
 
 .. |br| raw:: html
-   
+
    <br />
 
 .. note::
-   
+
    **If you use this cosmological code, please cite:**
    |br|
    A. Spurio Mancini et al.
-   *CosmoPower: emulating cosmological power spectra for accelerated Bayesian inference from next-generation surveys*
+   *CosmoPower: emulating cosmological power spectra for accelerated Bayesian
+   inference from next-generation surveys*
    (`arXiv:210603846 <https://arxiv.org/abs/2106.03846>`_)
-   
+
    And remember to cite any sources for trained networks you use.
 
 Usage
 -----
 
-After installing SOLikeT, you can use the ``CosmoPower`` theory codes by adding the ``soliket.CosmoPower`` code as a block in your parameter files.
+After installing SOLikeT, you can use the ``CosmoPower`` theory codes by adding
+the ``soliket.CosmoPower`` code as a block in your parameter files.
 """
 import os
 try:
@@ -130,7 +132,7 @@ class CosmoPower(BoltzmannBase):
 
         lmax = self.extra_args["lmax"] or cls_old["ell"].max()
 
-        cls = {"ell": np.arange(lmax+1).astype(int)}
+        cls = {"ell": np.arange(lmax + 1).astype(int)}
         ls = cls_old["ell"]
 
         for k in self.networks:
@@ -176,7 +178,7 @@ class CosmoPower(BoltzmannBase):
         if spectra in ["tt", "te", "tb", "ee", "et", "eb", "bb", "bt", "be"]:
             ellfac = ls * (ls + 1.0) / (2.0 * np.pi)
         elif spectra in ["pt", "pe", "pb", "tp", "ep", "bp"]:
-            ellfac = (ls * (ls + 1.0)) ** (3./2.) / (2.0 * np.pi)
+            ellfac = (ls * (ls + 1.0)) ** (3. / 2.) / (2.0 * np.pi)
         elif spectra in ["pp"]:
             ellfac = (ls * (ls + 1.0)) ** 2.0 / (2.0 * np.pi)
 
@@ -197,12 +199,12 @@ class CosmoPower(BoltzmannBase):
         if x == "t" or x == "e" or x == "b":
             res *= self._cmb_unit_factor(units, Tcmb)
         elif x == "p":
-            res *= 1./np.sqrt(2.0*np.pi)
+            res *= 1. / np.sqrt(2.0 * np.pi)
 
         if y == "t" or y == "e" or y == "b":
             res *= self._cmb_unit_factor(units, Tcmb)
         elif y == "p":
-            res *= 1./np.sqrt(2.0*np.pi)
+            res *= 1. / np.sqrt(2.0 * np.pi)
 
         return res
 

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -23,7 +23,7 @@ class CosmoPower(BoltzmannBase):
     network_path: str = "CP_paper/CMB"
     network_settings: InfoDict = { }
 
-    extra_args: InfoDict = { }
+    extra_args: InfoDict = None
 
     renames: dict = {
         "omega_b": ["ombh2", "omegabh2"],

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -25,15 +25,6 @@ class CosmoPower(BoltzmannBase):
 
     extra_args: InfoDict = None
 
-    renames: dict = {
-        "omega_b": ["ombh2", "omegabh2"],
-        "omega_cdm": ["omch2", "omegach2"],
-        "ln10^{10}A_s": ["logA"],
-        "n_s": ["ns"],
-        "h": [],
-        "tau_reio": ["tau"],
-    }
-
     def initialize(self) -> None:
         super().initialize()
 
@@ -79,16 +70,11 @@ class CosmoPower(BoltzmannBase):
         self.log.info(f"CosmoPower will expect the parameters {self.all_parameters}")
 
     def calculate(self, state: dict, want_derived: bool=True, **params) -> dict:
-        cmb_params = { }
-
-        for par in self.renames:
-            if par in params:
-                cmb_params[par] = [params[par]]
-            else:
-                for r in self.renames[par]:
-                    if r in params:
-                        cmb_params[par] = [params[r]]
-                        break
+        cmb_params = {
+            p : [ params[p] ] for p in params
+        } | {
+            self.translate_param(p) : [ params[p] ] for p in params
+        }
 
         ells = None
 
@@ -184,6 +170,3 @@ class CosmoPower(BoltzmannBase):
 
     def get_can_support_parameters(self) -> list:
         return self.all_parameters
-
-    def get_requirements(self) -> list:
-        return list(self.all_parameters)

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -61,6 +61,7 @@ class CosmoPower(BoltzmannBase):
             netdata["network"] = network
             netdata["parameters"] = list(network.parameters)
             netdata["lmax"] = network.modes.max()
+            netdata["has_ell_factor"] = nettype.get("has_ell_factor", False)
 
             self.all_parameters = self.all_parameters | set(network.parameters)
 
@@ -123,6 +124,10 @@ class CosmoPower(BoltzmannBase):
             ls_fac = np.ones_like(ls)
 
         for k in self.networks:
+            cl_fac = np.ones_like(ls_fac)
+            if self.networks[k]["has_ell_factor"]:
+                cl_fac = (2.0 * np.pi) / (ls * (ls + 1.0))
+
             cls[k][ls] = cls_old[k] * ls_fac * cmb_fac ** 2.0
             if np.any(np.isnan(cls[k])):
                 self.log.warning("CosmoPower used outside of trained "\

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -52,9 +52,9 @@ class CosmoPower(BoltzmannBase):
             elif nettype["type"] == "PCAplusNN":
                 network = cp.cosmopower_PCAplusNN( restore = True, restore_filename = netpath )
             elif self.stop_at_error:
-                raise ValueError(f"Unknown network type {nettype.type} for network {spectype}.")
+                raise ValueError(f"Unknown network type {nettype['type']} for network {spectype}.")
             else:
-                self.log.warn(f"Unknown network type {nettype.type} for network {spectype}: skipped!")
+                self.log.warn(f"Unknown network type {nettype['type']} for network {spectype}: skipped!")
 
             netdata["type"] = nettype["type"]
             netdata["log"] = nettype.get("log", True)

--- a/soliket/cosmopower.py
+++ b/soliket/cosmopower.py
@@ -137,6 +137,24 @@ class CosmoPower(BoltzmannBase):
         return cls
 
     def ell_factor(self, ls: np.ndarray, spectra: str) -> np.ndarray:
+        """Calculate the ell factor for a specific spectrum.
+        These prefactors are used to convert from Cell to Dell and vice-versa.
+        
+        See also:
+          cobaya.BoltzmannBase.get_Cl
+          camb.CAMBresults.get_cmb_power_spectra
+        
+        Keyword arguments:
+          ls -- the range of ells.
+          spectra -- a two-character string with each character being one of [tebp].
+        
+        Return:
+          ellfac -- an array filled with ell factors for the given spectrum.
+        
+        Example:
+          ell_factor(l, "tt") -> l(l+1)/(2 pi).
+          ell_factor(l, "pp") -> l^2(l+1)^2/(2 pi).
+        """
         ellfac = np.ones_like(ls).astype(float)
 
         if spectra in [ "tt", "te", "tb", "ee", "et", "eb", "bb", "bt", "be" ]:

--- a/soliket/tests/test_cosmopower.py
+++ b/soliket/tests/test_cosmopower.py
@@ -35,6 +35,27 @@ info_dict = {
             # ),
             "soliket_data_path": "soliket/data/CosmoPower",
             "stop_at_error": True,
+            
+            "network_settings" : {
+                # TT has been trained on log(Cl)
+                "tt" : {
+                    "type" : "NN",
+                    "log" : True,
+                    "filename" : "cmb_TT_NN"
+                },
+                # EE has been trained on log(Cl)
+                "ee" : {
+                    "type" : "NN",
+                    "log" : True,
+                    "filename" : "cmb_EE_NN"
+                },
+                # TE has been trained on Cl (*NOT* log(Cl)!)
+                "te" : {
+                    "type" : "PCAplusNN",
+                    "log" : False,
+                    "filename" : "cmb_TE_PCAplusNN"
+                },
+            }
         }
     },
 }
@@ -63,11 +84,33 @@ def test_cosmopower_against_camb():
     camb_cls = model_camb.theory['camb'].get_Cl()
 
     info_dict['theory'] = {
-                           "soliket.CosmoPower": {
-                           "soliket_data_path": "soliket/data/CosmoPower",
-                           "stop_at_error": True,
-                           "extra_args": {'lmax': camb_cls['ell'].max() + 1}}
+        "soliket.CosmoPower": {
+            # "soliket_data_path": os.path.normpath(
+            #     os.path.join(os.getcwd(), "../data/CosmoPower")
+            # ),
+            "soliket_data_path": "soliket/data/CosmoPower",
+            "stop_at_error": True,
+            "extra_args": {'lmax': camb_cls['ell'].max()},
+            
+            "network_settings" : {
+                "tt" : {
+                    "type" : "NN",
+                    "log" : True,
+                    "filename" : "cmb_TT_NN"
+                },
+                "ee" : {
+                    "type" : "NN",
+                    "log" : True,
+                    "filename" : "cmb_EE_NN"
+                },
+                "te" : {
+                    "type" : "PCAplusNN",
+                    "log" : False,
+                    "filename" : "cmb_TE_PCAplusNN"
+                },
+            }
         }
+    }
 
     model_cp = get_model(info_dict)
     logL_cp = float(model_cp.loglikes({})[0])

--- a/soliket/tests/test_cosmopower.py
+++ b/soliket/tests/test_cosmopower.py
@@ -31,34 +31,35 @@ info_dict = {
     "theory": {
         "soliket.CosmoPower": {
             "stop_at_error": True,
-            "network_settings" : {
-                "tt" : {
-                    "type" : "NN",
-                    "log" : True,
-                    "filename" : "cmb_TT_NN",
-                    # If your network has been trained on (l (l+1) / 2 pi) C_l, this flag needs to be set.
-                    "has_ell_factor" : False,
+            "network_settings": {
+                "tt": {
+                    "type": "NN",
+                    "log": True,
+                    "filename": "cmb_TT_NN",
+                    # If your network has been trained on (l (l+1) / 2 pi) C_l,
+                    # this flag needs to be set.
+                    "has_ell_factor": False,
                 },
-                "ee" : {
-                    "type" : "NN",
-                    "log" : True,
-                    "filename" : "cmb_EE_NN",
-                    "has_ell_factor" : False,
+                "ee": {
+                    "type": "NN",
+                    "log": True,
+                    "filename": "cmb_EE_NN",
+                    "has_ell_factor": False,
                 },
-                "te" : {
-                    "type" : "PCAplusNN",
+                "te": {
+                    "type": "PCAplusNN",
                     # Trained on Cl, not log(Cl)
-                    "log" : False,
-                    "filename" : "cmb_TE_PCAplusNN",
-                    "has_ell_factor" : False,
+                    "log": False,
+                    "filename": "cmb_TE_PCAplusNN",
+                    "has_ell_factor": False,
                 },
             },
-            "renames" : {
-                "ombh2" : "omega_b",
-                "omch2" : "omega_cdm",
-                "ns" : "n_s",
-                "logA" : "ln10^{10}A_s",
-                "tau" : "tau_reio"
+            "renames": {
+                "ombh2": "omega_b",
+                "omch2": "omega_cdm",
+                "ns": "n_s",
+                "logA": "ln10^{10}A_s",
+                "tau": "tau_reio"
             }
         }
     },
@@ -95,30 +96,30 @@ def test_cosmopower_against_camb(request):
         "soliket.CosmoPower": {
             "stop_at_error": True,
             "extra_args": {'lmax': camb_cls['ell'].max()},
-            
-            "network_settings" : {
-                "tt" : {
-                    "type" : "NN",
-                    "log" : True,
-                    "filename" : "cmb_TT_NN"
+
+            "network_settings": {
+                "tt": {
+                    "type": "NN",
+                    "log": True,
+                    "filename": "cmb_TT_NN"
                 },
-                "ee" : {
-                    "type" : "NN",
-                    "log" : True,
-                    "filename" : "cmb_EE_NN"
+                "ee": {
+                    "type": "NN",
+                    "log": True,
+                    "filename": "cmb_EE_NN"
                 },
-                "te" : {
-                    "type" : "PCAplusNN",
-                    "log" : False,
-                    "filename" : "cmb_TE_PCAplusNN"
+                "te": {
+                    "type": "PCAplusNN",
+                    "log": False,
+                    "filename": "cmb_TE_PCAplusNN"
                 },
             },
-            "renames" : {
-                "ombh2" : "omega_b",
-                "omch2" : "omega_cdm",
-                "ns" : "n_s",
-                "logA" : "ln10^{10}A_s",
-                "tau" : "tau_reio"
+            "renames": {
+                "ombh2": "omega_b",
+                "omch2": "omega_cdm",
+                "ns": "n_s",
+                "logA": "ln10^{10}A_s",
+                "tau": "tau_reio"
             }
         }
     }

--- a/soliket/tests/test_cosmopower.py
+++ b/soliket/tests/test_cosmopower.py
@@ -30,12 +30,7 @@ info_dict = {
     },
     "theory": {
         "soliket.CosmoPower": {
-            # "soliket_data_path": os.path.normpath(
-            #     os.path.join(os.getcwd(), "../data/CosmoPower")
-            # ),
-            "soliket_data_path": "soliket/data/CosmoPower",
             "stop_at_error": True,
-            
             "network_settings" : {
                 "tt" : {
                     "type" : "NN",
@@ -57,6 +52,13 @@ info_dict = {
                     "filename" : "cmb_TE_PCAplusNN",
                     "has_ell_factor" : False,
                 },
+            },
+            "renames" : {
+                "ombh2" : "omega_b",
+                "omch2" : "omega_cdm",
+                "ns" : "n_s",
+                "logA" : "ln10^{10}A_s",
+                "tau" : "tau_reio"
             }
         }
     },
@@ -87,10 +89,6 @@ def test_cosmopower_against_camb():
 
     info_dict['theory'] = {
         "soliket.CosmoPower": {
-            # "soliket_data_path": os.path.normpath(
-            #     os.path.join(os.getcwd(), "../data/CosmoPower")
-            # ),
-            "soliket_data_path": "soliket/data/CosmoPower",
             "stop_at_error": True,
             "extra_args": {'lmax': camb_cls['ell'].max()},
             
@@ -110,6 +108,13 @@ def test_cosmopower_against_camb():
                     "log" : False,
                     "filename" : "cmb_TE_PCAplusNN"
                 },
+            },
+            "renames" : {
+                "ombh2" : "omega_b",
+                "omch2" : "omega_cdm",
+                "ns" : "n_s",
+                "logA" : "ln10^{10}A_s",
+                "tau" : "tau_reio"
             }
         }
     }

--- a/soliket/tests/test_cosmopower.py
+++ b/soliket/tests/test_cosmopower.py
@@ -68,15 +68,15 @@ info_dict = {
 
 @pytest.mark.skipif(not HAS_COSMOPOWER, reason='test requires cosmopower')
 def test_cosmopower_theory(request):
-    info_dict['theory']['soliket.CosmoPower']['soliket_data_path'] = \
-        os.path.join(request.config.rootdir, 'soliket/data/CosmoPower')
+    info_dict['theory']['soliket.CosmoPower']['network_path'] = \
+        os.path.join(request.config.rootdir, 'soliket/data/CosmoPower/CP_paper/CMB')
     model_fiducial = get_model(info_dict)   # noqa F841
 
 
 @pytest.mark.skipif(not HAS_COSMOPOWER, reason='test requires cosmopower')
 def test_cosmopower_loglike(request):
-    info_dict['theory']['soliket.CosmoPower']['soliket_data_path'] = \
-        os.path.join(request.config.rootdir, 'soliket/data/CosmoPower')
+    info_dict['theory']['soliket.CosmoPower']['network_path'] = \
+        os.path.join(request.config.rootdir, 'soliket/data/CosmoPower/CP_paper/CMB')
     model_cp = get_model(info_dict)
 
     logL_cp = float(model_cp.loglikes({})[0])

--- a/soliket/tests/test_cosmopower.py
+++ b/soliket/tests/test_cosmopower.py
@@ -37,23 +37,25 @@ info_dict = {
             "stop_at_error": True,
             
             "network_settings" : {
-                # TT has been trained on log(Cl)
                 "tt" : {
                     "type" : "NN",
                     "log" : True,
-                    "filename" : "cmb_TT_NN"
+                    "filename" : "cmb_TT_NN",
+                    # If your network has been trained on (l (l+1) / 2 pi) C_l, this flag needs to be set.
+                    "has_ell_factor" : False,
                 },
-                # EE has been trained on log(Cl)
                 "ee" : {
                     "type" : "NN",
                     "log" : True,
-                    "filename" : "cmb_EE_NN"
+                    "filename" : "cmb_EE_NN",
+                    "has_ell_factor" : False,
                 },
-                # TE has been trained on Cl (*NOT* log(Cl)!)
                 "te" : {
                     "type" : "PCAplusNN",
+                    # Trained on Cl, not log(Cl)
                     "log" : False,
-                    "filename" : "cmb_TE_PCAplusNN"
+                    "filename" : "cmb_TE_PCAplusNN",
+                    "has_ell_factor" : False,
                 },
             }
         }

--- a/soliket/tests/test_cosmopower.py
+++ b/soliket/tests/test_cosmopower.py
@@ -70,6 +70,7 @@ info_dict = {
 def test_cosmopower_theory(request):
     info_dict['theory']['soliket.CosmoPower']['network_path'] = \
         os.path.join(request.config.rootdir, 'soliket/data/CosmoPower/CP_paper/CMB')
+
     model_fiducial = get_model(info_dict)   # noqa F841
 
 
@@ -96,7 +97,8 @@ def test_cosmopower_against_camb(request):
         "soliket.CosmoPower": {
             "stop_at_error": True,
             "extra_args": {'lmax': camb_cls['ell'].max()},
-
+            'network_path': os.path.join(request.config.rootdir,
+                                         'soliket/data/CosmoPower/CP_paper/CMB'),
             "network_settings": {
                 "tt": {
                     "type": "NN",


### PR DESCRIPTION
[CosmoPower](https://github.com/simonsobs/SOLikeT/blob/master/soliket/cosmopower.py) as it currently stands _requires_ the user to include a TT/TE/EE network of NN/PCAplusNN/NN type. Since this is a pretty strict set of requirements, this commit works on changing that.

Instead of each network being defined only by a network path, there is now a `network_settings` dict within the CosmoPower theory block, which lists each network and what type of network it specifies. This allows one to:

- include more or fewer networks than just TT/TE/EE (think inclusion of BB or pp).
- Added support for pp.
- specify the type of network for each spectrum. No longer is TE specified to be a PCA+NN type, but one can specify the network type for each network individually.
- The required input parameters are now checked at initialization instead.
- (4400ef093f89238cf073516aa8a43d03615bd684) If your network has been trained on D_ell instead of C_ell, you can set a flag that will take care of the prefactor (a necessity, based on personal experience).
- (cdf3e806d1877b22a9dc516082b956873a10e82f) Added networks for derived parameter calculation.

Some things that might be worthwhile adding before or after this merge include:
- Ensure that networks trained over different ell-ranges are supported (right now it still asserts every network operates over the same ell range, but this may not be necessarily true, see also point below).
- P(k), see also #84.
- ~~Derived parameter networks (see Boris Bolliet's work).~~ Added in cdf3e806d1877b22a9dc516082b956873a10e82f.
- A better pytest implementation.