### PR TITLE
BUG: pyCCL isn't optional due to cluster likelihood

### DIFF
--- a/soliket/__init__.py
+++ b/soliket/__init__.py
@@ -2,13 +2,18 @@ from .lensing import LensingLiteLikelihood, LensingLikelihood  # noqa: F401
 from .gaussian import GaussianLikelihood, MultiGaussianLikelihood  # noqa: F401
 # from .studentst import StudentstLikelihood  # noqa: F401
 from .ps import PSLikelihood, BinnedPSLikelihood  # noqa: F401
-from .clusters import ClusterLikelihood  # noqa: F401
 from .mflike import MFLike  # noqa: F401
 from .mflike import TheoryForge_MFLike
 from .xcorr import XcorrLikelihood  # noqa: F401
 from .foreground import Foreground
 from .bandpass import BandPass
 from .cosmopower import CosmoPower
+
+try:
+    from .clusters import ClusterLikelihood  # noqa: F401
+except ImportError:
+    print('Skipping cluster likelihood (is pyCCL installed?)')
+    pass
 
 try:
     import pyccl as ccl  # noqa: F401


### PR DESCRIPTION
I can't get pyCCL installed on the cluster I work on, so every time I checkout a different soliket branch, I need to manually disable the cluster likelihood because the test to see if pyCCL is installed doesn't extend to the cluster likelihood.

Adding a try-catch loop around the `from .clusters import ClusterLikelihood` call should fix this.