### PR TITLE
Updated test loglikes to match for camb v1.4.0

### DIFF
--- a/soliket/tests/test_clusters.py
+++ b/soliket/tests/test_clusters.py
@@ -26,6 +26,7 @@ info_fiducial = {
                 "nonlinear": False,
                 "kmax": 10.0,
                 "dark_energy_model": "ppf",
+                "bbn_predictor": "PArthENoPE_880.2_standard.dat"
             }
         },
     },
@@ -43,7 +44,7 @@ def test_clusters_loglike():
 
     lnl = model_fiducial.loglikes({})[0]
 
-    assert np.isclose(lnl, -855.0)
+    assert np.isclose(lnl, -854.89406321)
 
 
 def test_clusters_n_expected():

--- a/soliket/tests/test_cross_correlation.py
+++ b/soliket/tests/test_cross_correlation.py
@@ -160,7 +160,7 @@ def test_shearkappa_hartlap(request):
     model = get_model(info)
     loglikes_hartlap, derived = model.loglikes()
 
-    assert np.isclose(np.abs(loglikes - loglikes_hartlap), 0.00104092)
+    assert np.isclose(np.abs(loglikes - loglikes_hartlap), 0.0010403)
 
 
 def test_shearkappa_deltaz(request):


### PR DESCRIPTION
I have updated the loglikes values to match those computed by the newer camb version. I also more explicilty specify the BBN model, which made things closer to the previous values, but still not the same.

Merging will close #97 