### PR TITLE
Fix codecov not reporting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands =
     pip freeze
     cobaya-install planck_2018_highl_plik.TTTEEE_lite_native --no-set-global
     !cov: pytest --pyargs soliket {posargs}
-    cov: pytest --pyargs soliket --cov soliket --cov-config={toxinidir}/setup.cfg {posargs}
+    cov: pytest --pyargs soliket --cov soliket --cov-report=xml --cov-config={toxinidir}/setup.cfg {posargs}
 
 [testenv:codestyle]
 skip_install = true


### PR DESCRIPTION
Hopefully this is just adding the output of coverage to an xml file which is explicitly required bby the new uploader version. Merging will close #102 