### PR TITLE
modified camb dependency for M1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ portalocker
 dill
 fuzzywuzzy
 astropy
-camb
 getdist
 cobaya
 pyccl

--- a/soliket-tests.yml
+++ b/soliket-tests.yml
@@ -14,5 +14,6 @@ dependencies:
   - fftw
   - cython
   - mpi4py
+  - camb
   - pip:
       - -r requirements.txt


### PR DESCRIPTION
This PR should fix tox tests on M1 by removing camb from the pip requirements and add it to the conda requirements in soliket-tests.yml