### PR TITLE
Fixes to local docs build config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ extensions = [
     "sphinx.ext.autodoc", # Generate doc pages from source docstrings
     "sphinx.ext.viewcode", # Generate links to source code
     "sphinx.ext.mathjax", # Mathematical symbols
+    "sphinx_rtd_theme", # readthedocs theme
 ]
 
 templates_path = ['_templates']

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,9 @@ commands = flake8
 skip_install = true
 changedir = docs
 description = Make sphinx docs
-deps = sphinx
+deps =
+    sphinx
+    sphinx_rtd_theme
 commands =
     pip freeze
-    sphinx-build -W -b html . _build
+    sphinx-build -b html . _build


### PR DESCRIPTION
This fixes a few things which meant that `tox -e docs` was failing locally.