### PR TITLE
Remove dependence on installations from github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,4 @@ getdist
 cobaya
 pyccl
 sacc
-fgspectra @ git+https://github.com/simonsobs/fgspectra@act_sz_x_cib#egg=fgspectra
-mflike @ git+https://github.com/simonsobs/lat_mflike@master
+fgspectra


### PR DESCRIPTION
This removes our dependence on installing specfic branches of codes via github, instead of via pip. Installing deps via github is forbidden for us to be on PyPI (see #93 ).

