### PR TITLE
fixing mflike scales to [30,9000]

### DIFF
--- a/soliket/mflike/MFLike.yaml
+++ b/soliket/mflike/MFLike.yaml
@@ -22,11 +22,12 @@ defaults:
   # Which spectra?
   polarizations: ['TT', 'TE', 'ET', 'EE']
   # Scale cuts (in ell) for each spectrum
+  # these scales should be used when marginalizing over foregrounds!
   scales:
-    TT: [50, 5000]
-    TE: [50, 5000]
-    ET: [50, 5000]
-    EE: [50, 5000]
+    TT: [30, 9000]
+    TE: [30, 9000]
+    ET: [30, 9000]
+    EE: [30, 9000]
   # If True, TE' = (TE + ET) / 2 will be used
   # instead of TE and ET separately.
   symmetrize: False


### PR DESCRIPTION
The ell range used in mflike is too conservative, using the range [50,5000]. We changed it to [30,9000], to be used when marginalizing over foregrounds and using a multifrequency dataset.