### PR TITLE
Add compatibility workflow

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -8,30 +8,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        python: ['3.10']
-        toxenv: [py310-test, py310-test-dev]
-        release: [main, latest]
+        os: ubuntu-latest
+        python-version: '3.10'
+        toxenv: py310-test-all-latest
+        # release: [main, latest] # there are no releases yet so this would break
+        release: main
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - if: matrix.release != 'main'
-      name: Checkout Release
-      run: |
-        git checkout tags/$(curl -s https://api.github.com/repos/skypyproject/skypy/releases/${{ matrix.release }} | python -c "import sys, json; print(json.load(sys.stdin)['tag_name'])")
-    - name: Install Conda w/ Python ${{ matrix.python-version }}
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        auto-activate-base: false
-        python-version: ${{ matrix.python-version }}
-        channels: conda-forge
-    - name: Install Dependencies
-      shell: bash -el {0}
-      run: |
-        pip install tox-conda
-    - name: Run Tests
-      shell: bash -el {0}
-      run: |
-        tox -e ${{ matrix.toxenv }} ${{ matrix.toxargs }} -- ${{ matrix.toxposargs }}
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - if: matrix.release != 'main'
+        name: Checkout Release
+        run: |
+          git checkout tags/$(curl -s https://api.github.com/repos/simonsobs/SOLikeT/releases/${{ matrix.release }} | python -c "import sys, json; print(json.load(sys.stdin)['tag_name'])")
+      - name: Install Conda w/ Python ${{ matrix.python-version }}
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-activate-base: false
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+      - name: Install Dependencies
+        shell: bash -el {0}
+        run: |
+          pip install tox-conda
+      - name: Run Tests
+        shell: bash -el {0}
+        run: |
+          tox -e ${{ matrix.toxenv }} ${{ matrix.toxargs }} -- ${{ matrix.toxposargs }}

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,37 @@
+name: Compatibility
+on:
+  schedule:
+    - cron: '0 4 * * SUN'
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python: ['3.10']
+        toxenv: [py310-test, py310-test-dev]
+        release: [main, latest]
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - if: matrix.release != 'main'
+      name: Checkout Release
+      run: |
+        git checkout tags/$(curl -s https://api.github.com/repos/skypyproject/skypy/releases/${{ matrix.release }} | python -c "import sys, json; print(json.load(sys.stdin)['tag_name'])")
+    - name: Install Conda w/ Python ${{ matrix.python-version }}
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-activate-base: false
+        python-version: ${{ matrix.python-version }}
+        channels: conda-forge
+    - name: Install Dependencies
+      shell: bash -el {0}
+      run: |
+        pip install tox-conda
+    - name: Run Tests
+      shell: bash -el {0}
+      run: |
+        tox -e ${{ matrix.toxenv }} ${{ matrix.toxargs }} -- ${{ matrix.toxposargs }}


### PR DESCRIPTION
In order to detect failures due to changes in dependencies, add a compatibility workflow which runs the tests every Sunday with latest versions.