### PR TITLE
149 add nonlinear galaxy bias models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pyccl
 sacc
 fgspectra>=1.1.0
 syslibrary
+fast-pt

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ install_requires =
     sacc
     fgspectra>=1.1.0
     syslibrary
+    fast-pt
 
 [options.package_data]
 soliket = *.yaml,*.bibtex,clusters/data/*,clusters/data/selFn_equD56/*,lensing/data/*.txt,lensing/data/*.fits,mflike/*.yaml,tests/*.yaml,data/xcorr_simulated/*.txt,data/CosmoPower/CP_paper/CMB/*.pkl,tests/data/test_bandpass/*,cross_correlation/*.yaml,tests/data/*.fits

--- a/soliket-tests.yml
+++ b/soliket-tests.yml
@@ -17,3 +17,4 @@ dependencies:
   - camb
   - pip:
       - -r requirements.txt
+      - velocileptors @git+https://github.com/sfschen/velocileptors 

--- a/soliket/ccl.py
+++ b/soliket/ccl.py
@@ -159,6 +159,9 @@ class CCL(Theory):
 
         Omega_c = self.provider.get_param('omch2') / h ** 2
         Omega_b = self.provider.get_param('ombh2') / h ** 2
+        sigma8 =   self.provider.get_param('sigma8')
+        n_s = self.provider.get_param('ns')
+        mnu = self.provider.get_param('mnu')
         # Array z is sorted in ascending order. CCL requires an ascending scale factor
         # as input
         # Flip the arrays to make them a function of the increasing scale factor.
@@ -171,7 +174,6 @@ class CCL(Theory):
         a = 1. / (1 + self.z[::-1])
         # growth = ccl.background.growth_factor(cosmo, a)
         # fgrowth = ccl.background.growth_rate(cosmo, a)
-
         if self.kmax:
             for pair in self._var_pairs:
                 # Get the matter power spectrum:
@@ -189,8 +191,9 @@ class CCL(Theory):
                                                     Omega_c=Omega_c,
                                                     Omega_b=Omega_b,
                                                     h=h,
-                                                    sigma8=0.8,
-                                                    n_s=0.96,
+                                                    sigma8=sigma8,
+                                                    n_s=n_s,
+                                                    m_nu=mnu,
                                                     background={'a': a,
                                                                 'chi': distance,
                                                                 'h_over_h0': E_of_z},
@@ -207,8 +210,9 @@ class CCL(Theory):
                                                     Omega_c=Omega_c,
                                                     Omega_b=Omega_b,
                                                     h=h,
-                                                    sigma8=0.8,
-                                                    n_s=0.96,
+                                                    sigma8=sigma8,
+                                                    n_s=n_s,
+                                                    m_nu=mnu,
                                                     background={'a': a,
                                                                 'chi': distance,
                                                                 'h_over_h0': E_of_z},

--- a/soliket/cross_correlation/CrossCorrelationLikelihood.yaml
+++ b/soliket/cross_correlation/CrossCorrelationLikelihood.yaml
@@ -1,3 +1,4 @@
 datapath: soliket/tests/data/des_s-act_kappa.toy-sim.sacc.fits
 use_spectra: all
 ncovsims: null
+

--- a/soliket/cross_correlation/GalaxyKappaLikelihood.yaml
+++ b/soliket/cross_correlation/GalaxyKappaLikelihood.yaml
@@ -1,9 +1,13 @@
-params:
-  b1: 
-    prior:
-      min: 0.
-      max: 10.
-    latex: b_1
-  s1: 
-    value: 0.4
-    latex: s_1
+datapath: soliket/tests/data/des_s-act_kappa.toy-sim.sacc.fits
+use_spectra: all
+
+bins: gc_cmass
+bz_model: LagrangianPT
+nz_model: NzShift
+z_cmb: 1030
+input_params_prefix: '_'
+
+log10k_min: -4
+log10k_max: 2
+nk_per_decade: 20
+

--- a/soliket/cross_correlation/GalaxyKappaLikelihood.yaml
+++ b/soliket/cross_correlation/GalaxyKappaLikelihood.yaml
@@ -10,4 +10,6 @@ input_params_prefix: '_'
 log10k_min: -4
 log10k_max: 2
 nk_per_decade: 20
-
+defaults:
+  lmin: 30
+  lmax: 3000

--- a/soliket/cross_correlation/cross_correlation.py
+++ b/soliket/cross_correlation/cross_correlation.py
@@ -187,7 +187,6 @@ class GalaxyKappaLikelihood(CrossCorrelationLikelihood):
             tr1, tr2 = tr
             lmin = np.max([self.defaults[tr1]['lmin'], self.defaults[tr2]['lmin']])
             lmax = np.min([self.defaults[tr1]['lmax'], self.defaults[tr2]['lmax']]) 
-            print(tr, lmin, lmax)
             self.sacc_data.remove_selection(tracers=tr, ell__gt=lmax)
             self.sacc_data.remove_selection(tracers=tr, ell__lt=lmin)
 
@@ -316,6 +315,7 @@ class GalaxyKappaLikelihood(CrossCorrelationLikelihood):
             tr_x, tr_y = tr_pair
 
             ells_theory, w_bins = self.get_binning((tr_x, tr_y))
+            print(ells_theory)
 
             if self.PT_bias:
                 pk_xy = self.ptc.get_biased_pk2d(tracers[tr_x]['PT_tracer'], tracer2=tracers[tr_y]['PT_tracer'])
@@ -326,6 +326,7 @@ class GalaxyKappaLikelihood(CrossCorrelationLikelihood):
                                                    ells_theory)
 
             cl_binned = np.dot(w_bins, cl_unbinned)
+            print(cl_unbinned)
 
             cls.append(cl_binned)
 

--- a/soliket/cross_correlation/cross_correlation.py
+++ b/soliket/cross_correlation/cross_correlation.py
@@ -315,7 +315,6 @@ class GalaxyKappaLikelihood(CrossCorrelationLikelihood):
             tr_x, tr_y = tr_pair
 
             ells_theory, w_bins = self.get_binning((tr_x, tr_y))
-            print(ells_theory)
 
             if self.PT_bias:
                 pk_xy = self.ptc.get_biased_pk2d(tracers[tr_x]['PT_tracer'], tracer2=tracers[tr_y]['PT_tracer'])
@@ -326,7 +325,6 @@ class GalaxyKappaLikelihood(CrossCorrelationLikelihood):
                                                    ells_theory)
 
             cl_binned = np.dot(w_bins, cl_unbinned)
-            print(cl_unbinned)
 
             cls.append(cl_binned)
 

--- a/soliket/tests/test_cross_correlation.py
+++ b/soliket/tests/test_cross_correlation.py
@@ -323,7 +323,9 @@ def test_galaxykappa_pred(request):
 
     rootdir = request.config.rootdir
 
-    info = yaml.load(os.path.join(rootdir, galaxykappa_yaml_file), Loader=yaml.FullLoader)
+    with open(os.path.join(rootdir, galaxykappa_yaml_file), 'r') as f:
+        info = yaml.load(f, Loader=yaml.FullLoader)
+    info['datapath'] = os.path.join(rootdir, galaxykappa_sacc_file)
 
     params_dict =  {'sigma8': 0.8069016507, 
                     'omch2': 0.1206, 

--- a/soliket/tests/test_cross_correlation.py
+++ b/soliket/tests/test_cross_correlation.py
@@ -6,6 +6,8 @@ from cobaya.model import get_model
 
 gammakappa_sacc_file = 'soliket/tests/data/des_s-act_kappa.toy-sim.sacc.fits'
 gkappa_sacc_file = 'soliket/tests/data/gc_cmass-actdr4_kappa.sacc.fits'
+galaxykappa_yaml_file = 'soliket/tests/test_galaxykappalike.yaml'
+galaxykappa_sacc_file = 'soliket/tests/data/abacus_red-sn+cmbk_cov=sim-noise+theor-err_abacus.fits'
 
 cosmo_params = {"Omega_c": 0.25, "Omega_b": 0.05, "h": 0.67, "n_s": 0.96}
 
@@ -319,7 +321,9 @@ def test_galaxykappa_pred(request):
     import yaml
     import sacc
 
-    info = yaml.load('test_galaxykappalike.yaml', Loader=yaml.FullLoader)
+    rootdir = request.config.rootdir
+
+    info = yaml.load(os.path.join(rootdir, galaxykappa_yaml_file), Loader=yaml.FullLoader)
 
     params_dict =  {'sigma8': 0.8069016507, 
                     'omch2': 0.1206, 
@@ -356,7 +360,7 @@ def test_galaxykappa_pred(request):
     cosmo = ccl.Cosmology(Omega_c=Omega_c, Omega_b=Omega_b, h=params_dict['H0']/100., sigma8=params_dict['sigma8'], 
                             n_s=params_dict['ns'], m_nu=params_dict['mnu'], matter_power_spectrum='camb', 
                             extra_parameters={"camb": {"halofit_version": "mead2020"}})
-    s = sacc.Sacc.load_fits('data/abacus_red-sn+cmbk_cov=sim-noise+theor-err_abacus.fits')
+    s = sacc.Sacc.load_fits(os.path.join(rootdir, galaxykappa_sacc_file))
     sacc_tr = s.tracers['cl1']
     z_arr = sacc_tr.z
     nz_arr = sacc_tr.nz

--- a/soliket/tests/test_cross_correlation.py
+++ b/soliket/tests/test_cross_correlation.py
@@ -325,7 +325,8 @@ def test_galaxykappa_pred(request):
 
     with open(os.path.join(rootdir, galaxykappa_yaml_file), 'r') as f:
         info = yaml.load(f, Loader=yaml.FullLoader)
-    info['datapath'] = os.path.join(rootdir, galaxykappa_sacc_file)
+    info['likelihood']['soliket.cross_correlation.GalaxyKappaLikelihood']['datapath'] = os.path.join(rootdir, galaxykappa_sacc_file)
+    print(info)
 
     params_dict =  {'sigma8': 0.8069016507, 
                     'omch2': 0.1206, 

--- a/soliket/tests/test_galaxykappalike.yaml
+++ b/soliket/tests/test_galaxykappalike.yaml
@@ -1,18 +1,26 @@
 # A simple cobaya likelihood for SO
 
 debug: True
-stop_at_error: true
+stop_at_error: True
 
 likelihood:
-  soliket.cross_correlation.CrossCorrelationLikelihood:
+  soliket.cross_correlation.GalaxyKappaLikelihood:
+    input_params_prefix: gcl
     datapath: ../tests/data/gc_cmass-actdr4_kappa.sacc.fits
     use_spectra: all
-    bins: gc_cmass
+      # - bins:
+      #   - gc_cmass1
+      #   - gk_actdr4
+      # - bins:
+      #   - gc_cmass2
+      #   - gk_actdr4
+    bins: 
+      - gc_cmass
     bz_model: LagrangianPT
-    nz_model: NzShift
+    nz_model: NzNone
 
 params:
-  m_nu: 0.06
+  mnu: 0.06
   sigma8:
     prior:
       min: 0.1
@@ -23,20 +31,16 @@ params:
       scale: 0.01
     latex: \sigma_8
     proposal: 0.001
-  Omega_c:
+  omch2:
     prior:
-      min: 0.05
-      max: 0.7
-    ref:
-      dist: norm
-      loc: 0.265512666
-      scale: 0.01
-    latex: \Omega_c
-    proposal: 0.001
-  Omega_b: 0.049301692328524445
-  h: 0.6736
-  n_s: 0.9649
-  gc_cmass_b1:
+      min: 0.09
+      max: 0.15
+    proposal: 0.0011
+    latex: \Omega_\mathrm{c}h^2
+  ombh2: 0.0245
+  H0: 70.0
+  ns: 0.965
+  gcl_gc_cmass_b1:
     latex: b_1\,\text{for}\,C_{l,1}
     proposal: 0.01
     prior:
@@ -46,7 +50,7 @@ params:
       dist: norm
       loc: 1.56335764
       scale: 0.01
-  gc_cmass_b1p:
+  gcl_gc_cmass_b1p:
     latex: b_1p\,\text{for}\,C_{l,1}
     proposal: 0.01
     prior:
@@ -56,7 +60,7 @@ params:
       dist: norm
       loc: 1.34552581
       scale: 0.01
-  gc_cmass_b2:
+  gcl_gc_cmass_b2:
     latex: b_2\,\text{for}\,C_{l,1}
     proposal: 0.01
     prior:
@@ -66,8 +70,8 @@ params:
       dist: norm
       loc: 0.1934235
       scale: 0.01
-  gc_cmass_b3nl: 0.0
-  gc_cmass_bk2:
+  gcl_gc_cmass_b3nl: 0.0
+  gcl_gc_cmass_bk2:
     latex: b_k2\,\text{for}\,C_{l,1}
     proposal: 0.01
     prior:
@@ -77,7 +81,7 @@ params:
       dist: norm
       loc: -0.22069886
       scale: 0.01
-  gc_cmass_bs:
+  gcl_gc_cmass_bs:
     latex: b_s\,\text{for}\,C_{l,1}
     proposal: 0.01
     prior:
@@ -95,10 +99,9 @@ params:
 
 theory:
   camb:
-    extra_args:
-      num_massive_neutrinos: 0
+    stop_at_error: True
   soliket.ccl.CCL:
-    kmax: 10.0,
+    kmax: 10.0
     nonlinear: True
 
 sampler:

--- a/soliket/tests/test_galaxykappalike.yaml
+++ b/soliket/tests/test_galaxykappalike.yaml
@@ -6,7 +6,7 @@ stop_at_error: True
 likelihood:
   soliket.cross_correlation.GalaxyKappaLikelihood:
     input_params_prefix: gcl
-    datapath: /users/anicola/Work/projects/so_dev/abacus_red-sn+cmbk_cov=sim-noise+theor-err_abacus.fits
+    datapath: soliket/tests/data/abacus_red-sn+cmbk_cov=sim-noise+theor-err_abacus.fits
     use_spectra: 
       - bins:
         - cl1

--- a/soliket/tests/test_galaxykappalike.yaml
+++ b/soliket/tests/test_galaxykappalike.yaml
@@ -6,41 +6,111 @@ stop_at_error: True
 likelihood:
   soliket.cross_correlation.GalaxyKappaLikelihood:
     input_params_prefix: gcl
-    datapath: ../tests/data/gc_cmass-actdr4_kappa.sacc.fits
-    use_spectra: all
-      # - bins:
-      #   - gc_cmass1
-      #   - gk_actdr4
-      # - bins:
-      #   - gc_cmass2
-      #   - gk_actdr4
+    datapath: /users/anicola/Work/projects/so_dev/abacus_red-sn+cmbk_cov=sim-noise+theor-err_abacus.fits
+    use_spectra: 
+      - bins:
+        - cl1
+        - cmbk
+      - bins:
+        - cl2
+        - cmbk
+      - bins:
+        - cl3
+        - cmbk
     bins: 
-      - gc_cmass
+      - cl1
+      - cl2
+      - cl3
+      - cmbk
     bz_model: LagrangianPT
     nz_model: NzNone
+    defaults:
+      lmin: 30
+      lmax: 350
+      cl1: 
+        lmax: 350
+      cl2:
+        lmax: 500
+      cl3:
+        lmax: 600
 
 params:
-  mnu: 0.06
+  mnu: 0.0
   sigma8:
     prior:
       min: 0.1
       max: 1.2
-    ref:
-      dist: norm
-      loc: 0.8072376102
-      scale: 0.01
+    ref: 0.8069016507
+      # dist: norm
+      # loc: 0.809
+      # scale: 0.001
     latex: \sigma_8
     proposal: 0.001
   omch2:
     prior:
       min: 0.09
       max: 0.15
+    ref: 0.1206
+      # dist: norm
+      # loc: 0.116
+      # scale: 0.001
     proposal: 0.0011
     latex: \Omega_\mathrm{c}h^2
-  ombh2: 0.0245
-  H0: 70.0
-  ns: 0.965
-  gcl_gc_cmass_b1:
+  ombh2: 0.02237
+  H0: 67.36
+  ns: 0.9649
+  gcl_cl1_b1:
+    latex: b_1\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref: 1.585740073
+      # dist: norm
+      # loc: 1.58
+      # scale: 0.01
+  gcl_cl1_b1p:
+    latex: b_1p\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref: 1.369028161
+      # dist: norm
+      # loc: 1.36
+      # scale: 0.01
+  gcl_cl1_b2:
+    latex: b_2\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref: 0.2903571048
+      # dist: norm
+      # loc: 0.29
+      # scale: 0.01
+  gcl_cl1_b3nl: 0.0
+  gcl_cl1_bk2:
+    latex: b_k2\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref: 1.557112084
+      # dist: norm
+      # loc: 1.55
+      # scale: 0.01
+  gcl_cl1_bs:
+    latex: b_s\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref: -0.5728063156
+      # dist: norm
+      # loc: -0.57
+      # scale: 0.01
+  gcl_cl2_b1:
     latex: b_1\,\text{for}\,C_{l,1}
     proposal: 0.01
     prior:
@@ -48,9 +118,9 @@ params:
       max: 30.0
     ref:
       dist: norm
-      loc: 1.56335764
+      loc: 1.81
       scale: 0.01
-  gcl_gc_cmass_b1p:
+  gcl_cl2_b1p:
     latex: b_1p\,\text{for}\,C_{l,1}
     proposal: 0.01
     prior:
@@ -58,9 +128,9 @@ params:
       max: 30.0
     ref:
       dist: norm
-      loc: 1.34552581
+      loc: 1.85
       scale: 0.01
-  gcl_gc_cmass_b2:
+  gcl_cl2_b2:
     latex: b_2\,\text{for}\,C_{l,1}
     proposal: 0.01
     prior:
@@ -68,10 +138,10 @@ params:
       max: 30.0
     ref:
       dist: norm
-      loc: 0.1934235
+      loc: 0.46
       scale: 0.01
-  gcl_gc_cmass_b3nl: 0.0
-  gcl_gc_cmass_bk2:
+  gcl_cl2_b3nl: 0.0
+  gcl_cl2_bk2:
     latex: b_k2\,\text{for}\,C_{l,1}
     proposal: 0.01
     prior:
@@ -79,9 +149,9 @@ params:
       max: 30.0
     ref:
       dist: norm
-      loc: -0.22069886
+      loc: 2.35
       scale: 0.01
-  gcl_gc_cmass_bs:
+  gcl_cl2_bs:
     latex: b_s\,\text{for}\,C_{l,1}
     proposal: 0.01
     prior:
@@ -89,7 +159,58 @@ params:
       max: 30.0
     ref:
       dist: norm
-      loc: -0.3856291
+      loc: -1.1
+      scale: 0.01
+  gcl_cl3_b1:
+    latex: b_1\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref:
+      dist: norm
+      loc: 2.1
+      scale: 0.01
+  gcl_cl3_b1p:
+    latex: b_1p\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref:
+      dist: norm
+      loc: 2.2
+      scale: 0.01
+  gcl_cl3_b2:
+    latex: b_2\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref:
+      dist: norm
+      loc: 0.89
+      scale: 0.01
+  gcl_cl3_b3nl: 0.0
+  gcl_cl3_bk2:
+    latex: b_k2\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref:
+      dist: norm
+      loc: 4.0
+      scale: 0.01
+  gcl_cl3_bs:
+    latex: b_s\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref:
+      dist: norm
+      loc: -1.71
       scale: 0.01
 #  gc_cmass_bsn:
 #    latex: b_sn\,\text{for}\,C_{l,1}
@@ -100,9 +221,11 @@ params:
 theory:
   camb:
     stop_at_error: True
+    # extra_args:
+    #   non_linear_model: takahashi
   soliket.ccl.CCL:
     kmax: 10.0
-    nonlinear: True
+    # nonlinear: False
 
 sampler:
   evaluate:

--- a/soliket/tests/test_galaxykappalike.yaml
+++ b/soliket/tests/test_galaxykappalike.yaml
@@ -1,0 +1,107 @@
+# A simple cobaya likelihood for SO
+
+debug: True
+stop_at_error: true
+
+likelihood:
+  soliket.cross_correlation.CrossCorrelationLikelihood:
+    datapath: ../tests/data/gc_cmass-actdr4_kappa.sacc.fits
+    use_spectra: all
+    bins: gc_cmass
+    bz_model: LagrangianPT
+    nz_model: NzShift
+
+params:
+  m_nu: 0.06
+  sigma8:
+    prior:
+      min: 0.1
+      max: 1.2
+    ref:
+      dist: norm
+      loc: 0.8072376102
+      scale: 0.01
+    latex: \sigma_8
+    proposal: 0.001
+  Omega_c:
+    prior:
+      min: 0.05
+      max: 0.7
+    ref:
+      dist: norm
+      loc: 0.265512666
+      scale: 0.01
+    latex: \Omega_c
+    proposal: 0.001
+  Omega_b: 0.049301692328524445
+  h: 0.6736
+  n_s: 0.9649
+  gc_cmass_b1:
+    latex: b_1\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref:
+      dist: norm
+      loc: 1.56335764
+      scale: 0.01
+  gc_cmass_b1p:
+    latex: b_1p\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref:
+      dist: norm
+      loc: 1.34552581
+      scale: 0.01
+  gc_cmass_b2:
+    latex: b_2\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref:
+      dist: norm
+      loc: 0.1934235
+      scale: 0.01
+  gc_cmass_b3nl: 0.0
+  gc_cmass_bk2:
+    latex: b_k2\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref:
+      dist: norm
+      loc: -0.22069886
+      scale: 0.01
+  gc_cmass_bs:
+    latex: b_s\,\text{for}\,C_{l,1}
+    proposal: 0.01
+    prior:
+      min: -30.0
+      max: 30.0
+    ref:
+      dist: norm
+      loc: -0.3856291
+      scale: 0.01
+#  gc_cmass_bsn:
+#    latex: b_sn\,\text{for}\,C_{l,1}
+#    prior:
+#      max: 100000.0
+#      min: 0.0
+
+theory:
+  camb:
+    extra_args:
+      num_massive_neutrinos: 0
+  soliket.ccl.CCL:
+    kmax: 10.0,
+    nonlinear: True
+
+sampler:
+  evaluate:
+
+output: chains/test_galaxykappalike


### PR DESCRIPTION
This PR implements a wrapper to CCL nonlinear bias models. For the moment, it's just EPT and LPT but more models can be added once they are in CCL.