### PR TITLE
Dev check ell range mflike

### DIFF
--- a/soliket/foreground.py
+++ b/soliket/foreground.py
@@ -80,7 +80,7 @@ class Foreground(Theory):
         self.requested_cls = self.spectra["polarizations"]
         self.lmin = self.spectra["lmin"]
         self.lmax = self.spectra["lmax"]
-        self.ell = np.arange(self.lmin, self.lmax + 1)
+        #self.ell = np.arange(self.lmin, self.lmax + 1)
         self.exp_ch = self.spectra["exp_ch"]
         self.eff_freqs = self.spectra["eff_freqs"]
 
@@ -169,6 +169,7 @@ class Foreground(Theory):
         # useful to make tests at different l_max than the data
         if not hasattr(ell, '__len__'):
             ell = self.ell
+
         ell_0 = self.fg_ell_0
         nu_0 = self.fg_nu_0
 
@@ -307,7 +308,7 @@ class Foreground(Theory):
         if "fg_dict" in requirements:
             req = requirements["fg_dict"]
             self.requested_cls = req.get("requested_cls", self.requested_cls)
-            self.ell = req.get("ell", self.ell)
+            self.ell = req.get("ell", None)
             self.bands = req.get("bands", self.bands)
             self.exp_ch = req.get("exp_ch", self.exp_ch)
             return {"bandint_freqs": {"bands": self.bands}}
@@ -343,7 +344,10 @@ class Foreground(Theory):
             self.bandint_freqs = self.get_bandpasses(**params_values_dict)
 
         fg_params = {k: params_values_dict[k] for k in self.expected_params_fg}
+        self.log.info('%d', self.ell[-1])
+        self.log.info('%s', self.exp_ch)
         state["fg_dict"] = self._get_foreground_model(requested_cls=self.requested_cls,
+                                                      ell=self.ell,
                                                       exp_ch=self.exp_ch,
                                                       bandint_freqs=self.bandint_freqs,
                                                       **fg_params)

--- a/soliket/foreground.py
+++ b/soliket/foreground.py
@@ -80,7 +80,6 @@ class Foreground(Theory):
         self.requested_cls = self.spectra["polarizations"]
         self.lmin = self.spectra["lmin"]
         self.lmax = self.spectra["lmax"]
-        #self.ell = np.arange(self.lmin, self.lmax + 1)
         self.exp_ch = self.spectra["exp_ch"]
         self.eff_freqs = self.spectra["eff_freqs"]
 
@@ -344,8 +343,7 @@ class Foreground(Theory):
             self.bandint_freqs = self.get_bandpasses(**params_values_dict)
 
         fg_params = {k: params_values_dict[k] for k in self.expected_params_fg}
-        self.log.info('%d', self.ell[-1])
-        self.log.info('%s', self.exp_ch)
+        
         state["fg_dict"] = self._get_foreground_model(requested_cls=self.requested_cls,
                                                       ell=self.ell,
                                                       exp_ch=self.exp_ch,

--- a/soliket/mflike/mflike.py
+++ b/soliket/mflike/mflike.py
@@ -104,7 +104,7 @@ class MFLike(GaussianLikelihood, InstallableLikelihood):
                               "lcuts": self.lcuts,
                               "exp_ch": self.experiments,
                               "bands": self.bands}
-        self.log.info("%d",self.l_bpws)
+                              
         return reqs
 
     def _get_theory(self, **params_values):

--- a/soliket/mflike/mflike.py
+++ b/soliket/mflike/mflike.py
@@ -104,6 +104,7 @@ class MFLike(GaussianLikelihood, InstallableLikelihood):
                               "lcuts": self.lcuts,
                               "exp_ch": self.experiments,
                               "bands": self.bands}
+        self.log.info("%d",self.l_bpws)
         return reqs
 
     def _get_theory(self, **params_values):

--- a/soliket/mflike/theoryforge_MFLike.py
+++ b/soliket/mflike/theoryforge_MFLike.py
@@ -140,7 +140,6 @@ class TheoryForge_MFLike(Theory):
             self.lcuts = req.get("lcuts", self.lcuts)
             self.exp_ch = req.get("exp_ch", self.exp_ch)
             self.bands = req.get("bands", self.bands)
-            #self.log.info("%d",self.ell)
 
             # theoryforge requires Cl from boltzmann solver
         # and fg_dict from Foreground theory component
@@ -150,7 +149,7 @@ class TheoryForge_MFLike(Theory):
         # Be sure that CMB is computed at lmax > lmax_data (lcuts from mflike here)
         reqs["Cl"] = {k: max(c, self.lmax_boltzmann + 1) for k, c in self.lcuts.items()}
         reqs["fg_dict"] = {"requested_cls": self.requested_cls,
-                           "ell": self.ell,#np.arange(self.lmax_fg + 2),#np.arange(max(self.ell[-1], self.lmax_fg + 1)),
+                           "ell": self.ell,
                            "exp_ch": self.exp_ch, "bands": self.bands}
         return reqs
 
@@ -187,10 +186,6 @@ class TheoryForge_MFLike(Theory):
         :return: the CMB+foregrounds :math:`D_{\ell}` dictionary,
                  modulated by systematics
         """
-        #self.Dls = {s: Dls[s][self.ell] for s, _ in self.lcuts.items()}#Dls
-
-        #if self.ell is None:
-        #   self.ell = np.arange(self.lmin, self.lmax + 1)
 
         nuis_params = {k: params[k] for k in self.expected_params_nuis}
 
@@ -199,8 +194,6 @@ class TheoryForge_MFLike(Theory):
         for f1 in self.exp_ch:
             for f2 in self.exp_ch:
                 for s in self.requested_cls:
-                    #cmbfg_dict[s, f1, f2] = (self.Dls[s][self.ell] +
-                    #                         fg_dict[s, 'all', f1, f2][self.ell])
                     cmbfg_dict[s, f1, f2] = (self.Dls[s] +
                                              fg_dict[s, 'all', f1, f2])
 


### PR DESCRIPTION
This PR resolve some inconsistencies in the way the ell range was handled in soliket/mflike. In particular, the ell range is now common between cmb and fg spectra and is set via l_bpws read from the sacc file.