### PR TITLE
Compatability for scipy 1.14

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,8 +25,8 @@ jobs:
             python-version: '3.8'
             toxenv: py38-test-oldest
 
-          - name: macOS 11
-            os: macos-11
+          - name: macOS latest
+            os: macos-latest
             python-version: '3.11'
             toxenv: py311-test-latest
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install Conda w/ Python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-activate-base: false
           python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "requests",
     'importlib-metadata; python_version<"3.8"',
     "numpy",
-    "scipy",
+    "scipy>=1.6",
     "pandas", # to remove
     "astropy",
     "cobaya",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-scipy
+scipy>=1.6
 pandas
 scikit-learn
 pyyaml

--- a/soliket/clusters/tinker.py
+++ b/soliket/clusters/tinker.py
@@ -6,7 +6,7 @@ Parameters and functions used internally by the cluster likelihood for the Tinke
 """
 
 import numpy as np
-from scipy.integrate import simps
+from scipy.integrate import simpson
 from scipy.interpolate import InterpolatedUnivariateSpline as iuSpline
 
 # Tinker stuff

--- a/soliket/clusters/tinker.py
+++ b/soliket/clusters/tinker.py
@@ -129,7 +129,7 @@ def sigma_sq_integral(R_grid, power_spt, k_val):
         ) * k ** 2 for k, i in zip(k_val, np.arange(len(k_val)))]
     )
 
-    return simps(to_integ / (2 * np.pi ** 2), x=k_val, axis=0)
+    return simpson(to_integ / (2 * np.pi ** 2), x=k_val, axis=0)
 
 
 def dn_dlogM(M, z, rho, delta, k, P, comoving=False):


### PR DESCRIPTION
Simpson, eh?

Scipy 1.14 deprecates `scipy.integrate.simps` to `scipy.integrate.simpson`.

Change this in the code and update the requirements to be `scipy>=1.6` when this was introduced.