### PR TITLE
Add automated publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,7 +36,8 @@ jobs:
       - build
     runs-on: ubuntu-latest
     environment:
-      name: testpypi
+      name: pypi
+      url: https://pypi.org/p/soliket
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
@@ -45,10 +46,10 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
-      - name: Publish package distributions to TestPyPI
+      - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
+        # with:
           # user: __token__
-          repository-url: https://test.pypi.org/legacy/
+          # repository-url: https://test.pypi.org/legacy/
           # print-hash: true
           # password: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Upload to TestPyPI
+name: Upload to PyPI
 
 on:
   release:
@@ -31,7 +31,7 @@ jobs:
           path: dist/
 
   testpypi-publish:
-    name: Upload release to Test-PyPI
+    name: Upload release to PyPI
     needs:
       - build
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,54 @@
+name: Upload to TestPyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  testpypi-publish:
+    name: Upload release to Test-PyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish package distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # user: __token__
+          repository-url: https://test.pypi.org/legacy/
+          # print-hash: true
+          # password: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [project]
 name = "soliket"
-# version = "0.1.dev1"
 dynamic = ['version']
 authors = [
 	{name = "Simons Observatory"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ include = [
 "*" = ['*.yaml', '*.fits', '*.txt', '*.pkl', '*.gz']
 
 [tool.setuptools_scm]
-version_file = "soliket/version.py"
+version_file = "soliket/_version.py"
 
 [project.optional-dependencies]
 all = [


### PR DESCRIPTION
Automatically publish versioned releases to PyPI.

See this tagged release for a successful test:
https://github.com/simonsobs/SOLikeT/releases/tag/v0.1rc1.dev1
https://test.pypi.org/project/soliket/0.1rc1.dev1/