### PR TITLE
Add version import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ include = [
 "*" = ['*.yaml', '*.fits', '*.txt', '*.pkl', '*.gz']
 
 [tool.setuptools_scm]
+version_file = "soliket/_version.py"
 
 [project.optional-dependencies]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ include = [
 
 [tool.setuptools_scm]
 version_file = "soliket/_version.py"
+write_to = "soliket/_version.py"
 
 [project.optional-dependencies]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,6 @@ include = [
 "*" = ['*.yaml', '*.fits', '*.txt', '*.pkl', '*.gz']
 
 [tool.setuptools_scm]
-version_file = "soliket/_version.py"
-write_to = "soliket/_version.py"
 
 [project.optional-dependencies]
 all = [

--- a/soliket/__init__.py
+++ b/soliket/__init__.py
@@ -1,3 +1,5 @@
+from soliket._version import __version__
+
 from .bandpass import BandPass
 from .bias import Bias, Linear_bias
 from .ccl import CCL

--- a/soliket/__init__.py
+++ b/soliket/__init__.py
@@ -1,7 +1,7 @@
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = version("package-name")
+    __version__ = version("soliket")
 except PackageNotFoundError:
     # package is not installed
     pass

--- a/soliket/__init__.py
+++ b/soliket/__init__.py
@@ -1,4 +1,10 @@
-from soliket._version import __version__
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("package-name")
+except PackageNotFoundError:
+    # package is not installed
+    pass
 
 from .bandpass import BandPass
 from .bias import Bias, Linear_bias

--- a/soliket/tests/test_module.py
+++ b/soliket/tests/test_module.py
@@ -1,0 +1,10 @@
+
+def test_soliket_import():
+
+    import soliket
+
+def test_soliket_version():
+
+    import soliket
+
+    ver = soliket.__version__

--- a/soliket/tests/test_module.py
+++ b/soliket/tests/test_module.py
@@ -1,10 +1,8 @@
-
 def test_soliket_import():
+    import soliket  # noqa: F401
 
-    import soliket
 
 def test_soliket_version():
-
     import soliket
 
-    assert(soliket.__version__)
+    assert soliket.__version__

--- a/soliket/tests/test_module.py
+++ b/soliket/tests/test_module.py
@@ -7,4 +7,4 @@ def test_soliket_version():
 
     import soliket
 
-    ver = soliket.__version__
+    assert(soliket.__version__)


### PR DESCRIPTION
Following @ggalloni 's suggestion, fixes the fact the module did not have a `__version__` attribute.