### PR TITLE
Tests fail after #178 merged

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Dependencies
         shell: bash -el {0}
         run: |
-          pip install tox-conda flake8 "pip<21.1"
+          pip install tox-conda flake8 setuptools wheel
       - name: Check Code Style
         shell: bash -el {0}
         run: |

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Dependencies
         shell: bash -el {0}
         run: |
-          pip install tox-conda flake8 setuptools wheel
+          pip install tox-conda flake8 "setuptools<72" wheel
       - name: Check Code Style
         shell: bash -el {0}
         run: |

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Dependencies
         shell: bash -el {0}
         run: |
-          pip install tox-conda flake8 "setuptools<72" wheel
+          pip install tox-conda flake8 "setuptools<71.1" wheel
       - name: Check Code Style
         shell: bash -el {0}
         run: |

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Dependencies
         shell: bash -el {0}
         run: |
-          pip install tox-conda flake8 "setuptools<71.1" wheel
+          pip install tox flake8
       - name: Check Code Style
         shell: bash -el {0}
         run: |

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Dependencies
         shell: bash -el {0}
         run: |
-          pip install tox-conda flake8
+          pip install tox-conda flake8 "pip<21.1"
       - name: Check Code Style
         shell: bash -el {0}
         run: |

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           auto-activate-base: false
           activate-environment: soliket-tests
+          environment-file: soliket-tests.yml
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
       - name: Install Dependencies

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -24,12 +24,13 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-activate-base: false
+          activate-environment: soliket-tests
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
       - name: Install Dependencies
         shell: bash -el {0}
         run: |
-          pip install tox-conda
+          pip install tox
       - name: Run Tests
         shell: bash -el {0}
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           auto-activate-base: false
           activate-environment: soliket-tests
+          environment-file: soliket-tests.yml
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
       - name: Install Dependencies

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,12 +45,13 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-activate-base: false
+          activate-environment: soliket-tests
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
       - name: Install Dependencies
         shell: bash -el {0}
         run: |
-          pip install tox-conda
+          pip install tox
       - name: Run Tests
         shell: bash -el {0}
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "numpy",
     "scipy>=1.6",
     "pandas", # to remove
+    "pytest-cov",
     "astropy",
     "cobaya",
     "sacc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ version_file = "soliket/_version.py"
 [project.optional-dependencies]
 all = [
     "cosmopower",
-    "pyccl",
     "tensorflow_probability<0.22",
 ]
 docs = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 scipy>=1.6
 pandas
+pytest-cov
 scikit-learn
 pyyaml
 py-bobyqa

--- a/soliket-tests.yml
+++ b/soliket-tests.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - python>=3.8,<3.12
   - pip
+  - pytest
   - pytest-cov
   - compilers
   - make

--- a/soliket/bias/bias.py
+++ b/soliket/bias/bias.py
@@ -86,7 +86,7 @@ class Bias(Theory):
 
 
 class Linear_bias(Bias):
-    """
+    r"""
     :Synopsis: Linear bias model.
 
     Has one free parameter, :math:`b_\mathrm{lin}` (``b_lin``).

--- a/soliket/cosmopower/cosmopower.py
+++ b/soliket/cosmopower/cosmopower.py
@@ -220,7 +220,7 @@ class CosmoPower(BoltzmannBase):
         return cls
 
     def ell_factor(self, ls: np.ndarray, spectra: str) -> np.ndarray:
-        """
+        r"""
         Calculate the ell factor for a specific spectrum.
         These prefactors are used to convert from Cell to Dell and vice-versa.
 

--- a/soliket/mflike/mflike.py
+++ b/soliket/mflike/mflike.py
@@ -115,7 +115,7 @@ class MFLike(GaussianLikelihood, InstallableLikelihood):
         return self.loglike(cmbfg_dict)
 
     def loglike(self, cmbfg_dict):
-        """
+        r"""
         Computes the gaussian log-likelihood
 
         :param cmbfg_dict: the dictionary of theory + foregrounds
@@ -215,7 +215,7 @@ class MFLike(GaussianLikelihood, InstallableLikelihood):
             return exp_1, exp_2, pols, scls, symm
 
         def get_sacc_names(pol, exp_1, exp_2):
-            """
+            r"""
             Lower-level function of `prepare_data`.
             Translates the polarization combination and channel
             name of a given entry in the `spectra`
@@ -388,7 +388,7 @@ class MFLike(GaussianLikelihood, InstallableLikelihood):
         self.data = GaussianData("mflike", self.ell_vec, self.data_vec, self.cov)
 
     def _get_power_spectra(self, cmbfg):
-        """
+        r"""
         Get :math:`D_{\ell}` from the theory component
         already modified by ``theoryforge_MFLike``
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ requires =
     setuptools_scm >= 8
 	pip >= 19.3.1
 envlist =
-	py{38,39,310}-test{,-all}{,-latest,-oldest}{,-cov}
+	py{38,39,310,311}-test{,-all}{,-latest,-oldest}{,-cov}
 	codestyle
 
 [testenv]
@@ -43,7 +43,6 @@ extras =
 
 commands =
     conda info
-    conda list
     pip freeze
     all: cobaya-install planck_2018_highl_plik.TTTEEE_lite_native --no-set-global
     !cov: pytest -vv --rootdir={toxinidir} --pyargs {toxinidir}/soliket/ {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
 	tox-conda
 	setuptools >= 64
     setuptools_scm >= 8
-	pip >= 19.3.1
+	pip >= 19.3.1, <24.1
 envlist =
 	py{38,39,310}-test{,-all}{,-latest,-oldest}{,-cov}
 	codestyle

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
 	tox-conda
 	setuptools >= 64
     setuptools_scm >= 8
-	pip >= 19.3.1, <24.1
+	pip >= 19.3.1
 envlist =
 	py{38,39,310}-test{,-all}{,-latest,-oldest}{,-cov}
 	codestyle

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 requires =
-	#tox-conda
 	setuptools >= 64
     setuptools_scm >= 8
 	pip >= 19.3.1
@@ -12,11 +11,6 @@ envlist =
 allowlist_externals = 
     conda
     pytest
-#conda_env = soliket-tests.yml
-#conda_setup_args=
-#    --override-channels
-#conda_install_args=
-#    --override-channels
 
 setenv =
     COBAYA_PACKAGES_PATH = ./cobaya_packages
@@ -57,7 +51,6 @@ commands =
 
 [testenv:codestyle]
 skip_install = true
-# conda_env = 
 changedir = .
 description = check code style, e.g. with flake8
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 requires =
 	tox-conda
-	setuptools >= 30.3.0
+	setuptools >= 64
+    setuptools_scm >= 8
 	pip >= 19.3.1
 envlist =
 	py{38,39,310}-test{,-all}{,-latest,-oldest}{,-cov}

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
 	tox-conda
 	setuptools >= 64
     setuptools_scm >= 8
-	#pip >= 19.3.1
+	pip >= 19.3.1
 envlist =
 	py{38,39,310}-test{,-all}{,-latest,-oldest}{,-cov}
 	codestyle

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
 	tox-conda
 	setuptools >= 64
     setuptools_scm >= 8
-	pip >= 19.3.1
+	#pip >= 19.3.1
 envlist =
 	py{38,39,310}-test{,-all}{,-latest,-oldest}{,-cov}
 	codestyle

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,8 @@ extras =
     all: all
 
 commands =
+    conda info
+    conda list
     pip freeze
     all: cobaya-install planck_2018_highl_plik.TTTEEE_lite_native --no-set-global
     !cov: pytest -vv --rootdir={toxinidir} --pyargs {toxinidir}/soliket/ {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,9 @@ envlist =
 	codestyle
 
 [testenv]
-allowlist_externals = pytest conda
+allowlist_externals = 
+    conda
+    pytest
 #conda_env = soliket-tests.yml
 #conda_setup_args=
 #    --override-channels

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ extras =
     all: all
 
 commands =
+    conda activate soliket-tests
     conda info
     conda list
     pip freeze

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ requires =
 envlist =
 	py{38,39,310}-test{,-all}{,-latest,-oldest}{,-cov}
 	codestyle
+allowlist_externals = pytest
 
 [testenv]
 #conda_env = soliket-tests.yml
@@ -52,7 +53,7 @@ commands =
 
 [testenv:codestyle]
 skip_install = true
-conda_env = 
+# conda_env = 
 changedir = .
 description = check code style, e.g. with flake8
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 requires =
-	tox-conda
+	#tox-conda
 	setuptools >= 64
     setuptools_scm >= 8
 	pip >= 19.3.1
@@ -9,18 +9,18 @@ envlist =
 	codestyle
 
 [testenv]
-conda_env = soliket-tests.yml
-conda_setup_args=
-    --override-channels
-conda_install_args=
-    --override-channels
+#conda_env = soliket-tests.yml
+#conda_setup_args=
+#    --override-channels
+#conda_install_args=
+#    --override-channels
 
 setenv =
     COBAYA_PACKAGES_PATH = ./cobaya_packages
     SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL = True
 
 # Pass through the following environment variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CI TRAVIS
+passenv = HOME, WINDIR, LC_ALL, LC_CTYPE, CI, TRAVIS
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@ requires =
 envlist =
 	py{38,39,310}-test{,-all}{,-latest,-oldest}{,-cov}
 	codestyle
-allowlist_externals = pytest conda
 
 [testenv]
+allowlist_externals = pytest conda
 #conda_env = soliket-tests.yml
 #conda_setup_args=
 #    --override-channels

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,6 @@ extras =
     all: all
 
 commands =
-    conda activate soliket-tests
     conda info
     conda list
     pip freeze

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ requires =
 envlist =
 	py{38,39,310}-test{,-all}{,-latest,-oldest}{,-cov}
 	codestyle
-allowlist_externals = pytest
+allowlist_externals = pytest conda
 
 [testenv]
 #conda_env = soliket-tests.yml


### PR DESCRIPTION
Despite running when marked for review, the tests fail after #178 was merged.

The difference I can spot is a version bump in pip from 24.0 to 24.1

I have also added `setuptools_scm` to the tox `requires` as this cleans up differences I was seeing locallly vs the gh action runners.