### PR TITLE
Fix 'mflike' installation issues

### DIFF
--- a/examples/example_1.yaml
+++ b/examples/example_1.yaml
@@ -14,11 +14,11 @@ output: output/example_1
 # Note that MFLike is a Cobaya `installable likelihood`.
 # When running this yaml file, or calling `cobaya-install example_1.yaml` the required
 # installable components will automatically be downloaded and installed. 
-# Note that for the mflike.MFLike likelihood we are required to calculate:
+# Note that for the mflike.TTTEEE likelihood we are required to calculate:
 # - CMB theory power spectra (from CAMB theory below)
 # - Multi-frequency passband-integrated foregrounds (from mflike.BandpowerForeground theory below)
 likelihood:
-  mflike.MFLike:
+  mflike.TTTEEE:
     package_install: pip
     input_file: LAT_simu_sacc_00044.fits
     cov_Bbl_file: data_sacc_w_covar_and_Bbl.fits

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ sacc
 fgspectra>=1.1.0
 syslibrary
 pyhalomodel
+mflike

--- a/soliket/tests/test_lensing.py
+++ b/soliket/tests/test_lensing.py
@@ -30,7 +30,7 @@ def test_lensing_like(request):
         {"likelihood": {"soliket.lensing.LensingLikelihood": None}},
         path=packages_path,
         skip_global=False,
-        force=True,
+        force=False,
         debug=True,
         no_set_global=True,
     )
@@ -55,7 +55,7 @@ def test_lensing_ccl_limber(request):
         {"likelihood": {"soliket.lensing.LensingLikelihood": None}},
         path=packages_path,
         skip_global=False,
-        force=True,
+        force=False,
         debug=True,
         no_set_global=True,
     )

--- a/soliket/tests/test_mflike.py
+++ b/soliket/tests/test_mflike.py
@@ -3,7 +3,7 @@ from cobaya.tools import resolve_packages_path
 packages_path = resolve_packages_path()
 
 
-def test_import():
+def test_mflike_import():
 
     import mflike  # noqa: F401
 
@@ -12,7 +12,7 @@ def test_import():
     from mflike import TTTEEE, TT, EE, TE # noqa: F401
 
 
-def test_install(request):
+def test_mflike_install(request):
     from cobaya.install import install
 
     mflike_options = {

--- a/soliket/tests/test_mflike.py
+++ b/soliket/tests/test_mflike.py
@@ -1,3 +1,8 @@
+from cobaya.tools import resolve_packages_path
+
+packages_path = resolve_packages_path()
+
+
 def test_import():
 
     import mflike  # noqa: F401
@@ -5,3 +10,22 @@ def test_import():
     from mflike import BandpowerForeground, Foreground # noqa: F401
 
     from mflike import TTTEEE, TT, EE, TE # noqa: F401
+
+
+def test_install(request):
+    from cobaya.install import install
+
+    mflike_options = {
+        "input_file": "LAT_simu_sacc_00044.fits",
+        "cov_Bbl_file": "data_sacc_w_covar_and_Bbl.fits",
+        "stop_at_error": True,
+    }
+
+    install(
+        {"likelihood": {"mflike.TTTEEE": mflike_options}},
+        path=packages_path,
+        skip_global=False,
+        force=False,
+        debug=True,
+        no_set_global=True,
+    )

--- a/soliket/tests/test_multi.py
+++ b/soliket/tests/test_multi.py
@@ -38,6 +38,28 @@ nuisance_params = {
 }
 
 
+def test_lensing_and_mflike_installations():
+    import mflike
+
+    from soliket import LensingLikelihood
+
+    is_installed = LensingLikelihood.is_installed(
+        path=packages_path,
+    )
+    assert is_installed is True, (
+        "LensingLikelihood is not installed! Please install it using "
+        "'cobaya-install soliket.LensingLikelihood'"
+    )
+
+    is_installed = mflike.TTTEEE.is_installed(
+        path=packages_path,
+    )
+    assert is_installed is True, (
+        "mflike.TTTEEE is not installed! Please install it using "
+        "'cobaya-install mflike.TTTEEE'"
+    )
+
+
 def test_multi(test_cosmology_params):
     lensing_options = {"theory_lmax": 5000}
 

--- a/soliket/tests/test_runs.py
+++ b/soliket/tests/test_runs.py
@@ -1,11 +1,40 @@
 import pkgutil
 
 import pytest
+from cobaya.install import install
 from cobaya.run import run
 from cobaya.tools import resolve_packages_path
 from cobaya.yaml import yaml_load
 
 packages_path = resolve_packages_path()
+
+
+@pytest.mark.parametrize("lhood",
+                         ["lensing",
+                          "multi",
+                          ])
+def test_installation(lhood):
+    if lhood == "lensing":
+        from soliket import LensingLikelihood
+
+        is_installed = LensingLikelihood.is_installed(
+            path=packages_path,
+        )
+        assert is_installed is True, (
+            "LensingLikelihood is not installed! Please install it using "
+            "'cobaya-install soliket.LensingLikelihood'"
+        )
+
+    elif lhood == "multi":
+        import mflike
+
+        is_installed = mflike.TTTEEE.is_installed(
+            path=packages_path,
+        )
+        assert is_installed is True, (
+            "mflike.TTTEEE is not installed! Please install it using "
+            "'cobaya-install mflike.TTTEEE'"
+        )
 
 
 @pytest.mark.parametrize("lhood",
@@ -21,7 +50,6 @@ def test_evaluate(lhood):
     info["force"] = True
     info['sampler'] = {'evaluate': {}}
 
-    from cobaya.install import install
     install(info, path=packages_path, skip_global=True, no_set_global=True)
 
     updated_info, sampler = run(info)
@@ -40,7 +68,6 @@ def test_mcmc(lhood):
     info["force"] = True
     info['sampler'] = {'mcmc': {'max_samples': 10, 'max_tries': 1000}}
 
-    from cobaya.install import install
     install(info, path=packages_path, skip_global=True, no_set_global=True)
 
     updated_info, sampler = run(info)


### PR DESCRIPTION
This PR fixes some issues with 'mflike' installation.

- [x] fix naming in 'example_1.yaml'
- [x] add 'mflike' to requirements
- [x] add test downloading data for mflike if not already present
- [x] add tests to ensure the proper data are there when running the 'MultiGaussian' 