### PR TITLE
Change range of 'Python' version and fix 'pyccl'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "Likelihood and Theory codes for the Simons Observatory."
 readme = "README.rst"
-requires-python = ">=3.9,<=3.12"
+requires-python = ">=3.9,<=3.11"
 license = { text = "MIT" }
 dependencies = [
     "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "cobaya",
     "sacc",
     "fgspectra >= 1.1.0",
-    "pyccl >= 3.0; platform_system!='Windows'",
+    "pyccl == 3.2.0; platform_system!='Windows'",
     "pyhalomodel",
     "camb",
     "getdist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "Likelihood and Theory codes for the Simons Observatory."
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.9,<=3.12"
 license = { text = "MIT" }
 dependencies = [
     "requests",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ fuzzywuzzy
 astropy
 getdist
 cobaya
-pyccl >= 3.0; platform_system!='Windows'
+pyccl == 3.2.0; platform_system!='Windows'
 sacc
 fgspectra>=1.1.0
 syslibrary

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ pyyaml
 py-bobyqa
 packaging
 tqdm
-tensorflow<2.14
 portalocker
 dill
 fuzzywuzzy

--- a/soliket-tests.yml
+++ b/soliket-tests.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python>=3.9,<=3.12
+  - python>=3.9,<=3.11
   - pip
   - pytest
   - pytest-cov

--- a/soliket-tests.yml
+++ b/soliket-tests.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python>=3.8
+  - python>=3.9,<=3.12
   - pip
   - pytest
   - pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ requires =
     setuptools_scm >= 8
 	pip >= 19.3.1
 envlist =
-	py{39,310,311}-test{,-all}{,-latest,-oldest}{,-cov}
+	py{39,310,311,312}-test{,-all}{,-latest,-oldest}{,-cov}
 	codestyle
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ requires =
     setuptools_scm >= 8
 	pip >= 19.3.1
 envlist =
-	py{39,310,311,312}-test{,-all}{,-latest,-oldest}{,-cov}
+	py{39,310,311}-test{,-all}{,-latest,-oldest}{,-cov}
 	codestyle
 
 [testenv]


### PR DESCRIPTION
This PR changes the range of available 'python' versions to >=3.9 (note that this was already the case in the 'pyproject.toml', but not in the 'requirements.txt') <=3.11. 

Python 3.12 is not compatible with 'tensorflow', so 'cosmopower' is not available.
Python 3.13 is also not compatible with 'pyhalomodel'.

Also, here I fix 'pyccl' to '3.2.0' to avoid compatibility issues (see #194 for example)