### PR TITLE
Add global tolerance of like tests and collect reference values

### DIFF
--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -108,11 +108,12 @@ Pull requests will require existing unit tests to pass before they can be merged
  tests/test_my_module.py
 
 
-For Likelihoods we request that there is a test which compares the result of a likelihood calculation to a precomputed expected value which is hard coded in the tests file, to a tolerance of ``1.e-3``
+For Likelihoods we request that there is a test which compares the result of a likelihood calculation to a precomputed expected value which is hard coded in the tests file, to a tolerance of ``1.e-3``. Both the tolerances and the reference values of all likelihoods are stored in the `tests` folder within `likelihood_refs.yaml`. To use them in your test, you can rely on the `likelihood_refs` fixture, which reads and stores the values contained in that file. Thus, it is sufficient to do
 
 .. code-block:: bash
 
-  assert np.isclose(loglike_just_computed, -25.053, rtol=1.e-3)
+  ref = likelihood_refs["your_like_name"]
+  assert np.isclose(loglike_just_computed, ref["value"], rtol=ref["rtol"], atol=ref["atol"])
 
 For more advice on how to write tests see the `Astropy Testing Guidelines <https://docs.astropy.org/en/stable/development/testguide.html>`_.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,11 @@
 import pytest
+from cobaya.yaml import yaml_load_file
+
+
+@pytest.fixture(scope="session")
+def likelihood_refs():
+    yaml_path = "tests/likelihood_refs.yaml"
+    return yaml_load_file(yaml_path)
 
 
 @pytest.fixture

--- a/tests/likelihood_refs.yaml
+++ b/tests/likelihood_refs.yaml
@@ -1,0 +1,75 @@
+# ======= TOLERANCE =======
+
+rtol: &rtol 1e-3
+atol: &atol 1e-3
+
+# ====== REFERENCES =======
+
+# If needed individual tolerances can be modified
+
+cash:
+  value: -37.3710640070228
+  rtol: *rtol
+  atol: *atol
+cash_2d:
+  value: -2349.5353718742294
+  rtol: *rtol
+  atol: *atol
+
+clusters:
+  value: -847.22462272
+  rtol: *rtol
+  atol: *atol
+
+cosmopower:
+  value: -295.139
+  rtol: *rtol
+  atol: *atol
+
+galaxykappa:
+  value: 173.69192885580344
+  rtol: *rtol
+  atol: *atol
+shearkappa:
+  value: 637.64473666
+  rtol: *rtol
+  atol: *atol
+shearkappa_deltaz:
+  value: -7910.043704938653
+  rtol: *rtol
+  atol: *atol
+shearkappa_m:
+  value: -3737.5531377692337
+  rtol: *rtol
+  atol: *atol
+shearkappa_ia_nla_noevo:
+  value: -111712.15660832982
+  rtol: *rtol
+  atol: *atol
+shearkappa_ia_nla:
+  value: -114145.55021412153
+  rtol: *rtol
+  atol: *atol
+shearkappa_ia_perbin:
+  value: -100164.38521295182
+  rtol: *rtol
+  atol: *atol
+shearkappa_hmcode:
+  value: -20679.897354035915
+  rtol: *rtol
+  atol: *atol
+
+lensing:
+  value: 335.8560097798468
+  rtol: *rtol
+  atol: *atol
+
+multi:
+  value: -503.395
+  rtol: *rtol
+  atol: *atol
+
+ps:
+  value: -295.139
+  rtol: *rtol
+  atol: *atol

--- a/tests/test_cash.py
+++ b/tests/test_cash.py
@@ -32,35 +32,46 @@ def test_cash_read_data(request):
 
     from soliket.cash import CashCLikelihood
 
-    cash_data_path = os.path.join(
-        request.config.rootdir, "tests/data/cash_data.txt"
-    )
+    cash_data_path = os.path.join(request.config.rootdir, "tests/data/cash_data.txt")
 
     cash_lkl = CashCLikelihood({"datapath": cash_data_path})
     cash_data = cash_lkl._get_data()
     assert np.allclose(cash_data[1], np.arange(20))
 
 
-def test_cash_logp(request):
+def test_cash_logp(request, likelihood_refs):
     import os
 
     from soliket.cash import CashCLikelihood
 
+    ref = likelihood_refs["cash"]
+
     params = {"cash_test_logp": 20}
-    cash_data_path = os.path.join(
-        request.config.rootdir, "tests/data/cash_data.txt"
-    )
+    cash_data_path = os.path.join(request.config.rootdir, "tests/data/cash_data.txt")
 
     cash_lkl = CashCLikelihood({"datapath": cash_data_path})
     cash_logp = cash_lkl.logp(**params)
-    assert np.allclose(cash_logp, -37.3710640070228)
+    assert np.allclose(cash_logp, ref["value"], rtol=ref["rtol"], atol=ref["atol"])
 
 
-def test_cash():
+def test_cash(likelihood_refs):
     data1d, theory1d, data2d, theory2d = toy_data()
 
     cashdata1d = CashCData("toy 1d", data1d)
     cashdata2d = CashCData("toy 2d", data2d)
 
-    assert np.allclose(cashdata1d.loglike(theory1d), -37.3710640070228)
-    assert np.allclose(cashdata2d.loglike(theory2d), -2349.5353718742294)
+    ref_1d = likelihood_refs["cash"]
+    ref_2d = likelihood_refs["cash_2d"]
+
+    assert np.allclose(
+        cashdata1d.loglike(theory1d),
+        ref_1d["value"],
+        rtol=ref_1d["rtol"],
+        atol=ref_1d["atol"],
+    )
+    assert np.allclose(
+        cashdata2d.loglike(theory2d),
+        ref_2d["value"],
+        rtol=ref_2d["rtol"],
+        atol=ref_2d["atol"],
+    )

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -26,18 +26,25 @@ def test_clusters_model(check_skip_pyccl, evaluate_one_info, test_cosmology_para
     _ = get_model(evaluate_one_info)
 
 
-def test_clusters_loglike(check_skip_pyccl, evaluate_one_info, test_cosmology_params):
+def test_clusters_loglike(
+    check_skip_pyccl, evaluate_one_info, test_cosmology_params, likelihood_refs
+):
+    ref = likelihood_refs["clusters"]
+
     evaluate_one_info["params"] = test_cosmology_params
     evaluate_one_info.update(clusters_like_and_theory)
 
     model_fiducial = get_model(evaluate_one_info)
 
     lnl = model_fiducial.loglikes({})[0]
+    assert np.isclose(lnl, ref["value"], rtol=ref["rtol"], atol=ref["atol"])
 
-    assert np.isclose(lnl, -847.22462272, rtol=1.0e-3, atol=1.0e-5)
 
+def test_clusters_n_expected(
+    check_skip_pyccl, evaluate_one_info, test_cosmology_params, likelihood_refs
+):
+    ref = likelihood_refs["clusters"]
 
-def test_clusters_n_expected(check_skip_pyccl, evaluate_one_info, test_cosmology_params):
     evaluate_one_info["params"] = test_cosmology_params
     evaluate_one_info.update(clusters_like_and_theory)
 
@@ -47,5 +54,5 @@ def test_clusters_n_expected(check_skip_pyccl, evaluate_one_info, test_cosmology
 
     like = model_fiducial.likelihood["soliket.ClusterLikelihood"]
 
-    assert np.isclose(lnl, -847.22462272, rtol=1.0e-3, atol=1.0e-5)
+    assert np.isclose(lnl, ref["value"], rtol=ref["rtol"], atol=ref["atol"])
     assert like._get_n_expected() > 40

--- a/tests/test_cosmopower.py
+++ b/tests/test_cosmopower.py
@@ -104,7 +104,10 @@ def test_cosmopower_theory(request, check_skip_cosmopower, install_planck_lite):
     _ = get_model(info_dict)
 
 
-def test_cosmopower_loglike(request, check_skip_cosmopower, install_planck_lite):
+def test_cosmopower_loglike(
+    request, check_skip_cosmopower, install_planck_lite, likelihood_refs
+):
+    ref = likelihood_refs["cosmopower"]
     info_dict["theory"]["soliket.CosmoPower"]["network_path"] = os.path.join(
         request.config.rootdir, "soliket/cosmopower/data/CP_paper"
     )
@@ -112,7 +115,7 @@ def test_cosmopower_loglike(request, check_skip_cosmopower, install_planck_lite)
 
     logL_cp = float(model_cp.loglikes({})[0])
 
-    assert np.isclose(logL_cp, -295.139)
+    assert np.isclose(logL_cp, ref["value"], rtol=ref["rtol"], atol=ref["atol"])
 
 
 def test_cosmopower_against_camb(request, check_skip_cosmopower, install_planck_lite):

--- a/tests/test_cross_correlation.py
+++ b/tests/test_cross_correlation.py
@@ -119,9 +119,11 @@ def test_shearkappa_model(
 
 
 def test_galaxykappa_like(
-    request, check_skip_pyccl, evaluate_one_info, test_cosmology_params
+    request, check_skip_pyccl, evaluate_one_info, test_cosmology_params, likelihood_refs
 ):
     from soliket.cross_correlation import GalaxyKappaLikelihood
+
+    ref = likelihood_refs["galaxykappa"]
 
     evaluate_one_info["params"] = test_cosmology_params
     evaluate_one_info["params"].update(cross_correlation_params)
@@ -138,11 +140,13 @@ def test_galaxykappa_like(
     model = get_model(evaluate_one_info)
     loglikes, derived = model.loglikes()
 
-    assert np.isclose(loglikes[0], 173.69192885580344, atol=0.2, rtol=0.0)
+    assert np.isclose(loglikes[0], ref["value"], rtol=ref["rtol"], atol=ref["atol"])
 
 
-def test_shearkappa_like(request, check_skip_pyccl, evaluate_one_info):
+def test_shearkappa_like(request, check_skip_pyccl, evaluate_one_info, likelihood_refs):
     from soliket.cross_correlation import ShearKappaLikelihood
+
+    ref = likelihood_refs["shearkappa"]
 
     evaluate_one_info["theory"] = cross_correlation_theory
 
@@ -175,7 +179,7 @@ def test_shearkappa_like(request, check_skip_pyccl, evaluate_one_info):
     model = get_model(evaluate_one_info)
     loglikes, derived = model.loglikes()
 
-    assert np.isclose(loglikes, 637.64473666)
+    assert np.isclose(loglikes, ref["value"], rtol=ref["rtol"], atol=ref["atol"])
 
 
 def test_shearkappa_tracerselect(
@@ -289,9 +293,11 @@ def test_shearkappa_hartlap(request, check_skip_pyccl, evaluate_one_info):
 
 
 def test_shearkappa_deltaz(
-    request, check_skip_pyccl, evaluate_one_info, test_cosmology_params
+    request, check_skip_pyccl, evaluate_one_info, test_cosmology_params, likelihood_refs
 ):
     from soliket.cross_correlation import ShearKappaLikelihood
+
+    ref = likelihood_refs["shearkappa_deltaz"]
 
     evaluate_one_info["params"] = test_cosmology_params
     evaluate_one_info["theory"] = cross_correlation_theory
@@ -307,13 +313,15 @@ def test_shearkappa_deltaz(
     model = get_model(evaluate_one_info)
     loglikes, derived = model.loglikes()
 
-    assert np.isclose(loglikes[0], -7910.043704938653, atol=0.2, rtol=0.0)
+    assert np.isclose(loglikes[0], ref["value"], rtol=ref["rtol"], atol=ref["atol"])
 
 
 def test_shearkappa_m(
-    request, check_skip_pyccl, evaluate_one_info, test_cosmology_params
+    request, check_skip_pyccl, evaluate_one_info, test_cosmology_params, likelihood_refs
 ):
     from soliket.cross_correlation import ShearKappaLikelihood
+
+    ref = likelihood_refs["shearkappa_m"]
 
     evaluate_one_info["params"] = test_cosmology_params
     evaluate_one_info["theory"] = cross_correlation_theory
@@ -329,13 +337,15 @@ def test_shearkappa_m(
     model = get_model(evaluate_one_info)
     loglikes, derived = model.loglikes()
 
-    assert np.isclose(loglikes[0], -3737.5531377692337, atol=0.2, rtol=0.0)
+    assert np.isclose(loglikes[0], ref["value"], rtol=ref["rtol"], atol=ref["atol"])
 
 
 def test_shearkappa_ia_nla_noevo(
-    request, check_skip_pyccl, evaluate_one_info, test_cosmology_params
+    request, check_skip_pyccl, evaluate_one_info, test_cosmology_params, likelihood_refs
 ):
     from soliket.cross_correlation import ShearKappaLikelihood
+
+    ref = likelihood_refs["shearkappa_ia_nla_noevo"]
 
     evaluate_one_info["params"] = test_cosmology_params
     evaluate_one_info["theory"] = cross_correlation_theory
@@ -351,13 +361,15 @@ def test_shearkappa_ia_nla_noevo(
     model = get_model(evaluate_one_info)
     loglikes, derived = model.loglikes()
 
-    assert np.isclose(loglikes[0], -111712.15660832982, atol=0.2, rtol=0.0)
+    assert np.isclose(loglikes[0], ref["value"], rtol=ref["rtol"], atol=ref["atol"])
 
 
 def test_shearkappa_ia_nla(
-    request, check_skip_pyccl, evaluate_one_info, test_cosmology_params
+    request, check_skip_pyccl, evaluate_one_info, test_cosmology_params, likelihood_refs
 ):
     from soliket.cross_correlation import ShearKappaLikelihood
+
+    ref = likelihood_refs["shearkappa_ia_nla"]
 
     evaluate_one_info["params"] = test_cosmology_params
     evaluate_one_info["theory"] = cross_correlation_theory
@@ -375,13 +387,15 @@ def test_shearkappa_ia_nla(
     model = get_model(evaluate_one_info)
     loglikes, derived = model.loglikes()
 
-    assert np.isclose(loglikes[0], -114145.55021412153, atol=0.2, rtol=0.0)
+    assert np.isclose(loglikes[0], ref["value"], rtol=ref["rtol"], atol=ref["atol"])
 
 
 def test_shearkappa_ia_perbin(
-    request, check_skip_pyccl, evaluate_one_info, test_cosmology_params
+    request, check_skip_pyccl, evaluate_one_info, test_cosmology_params, likelihood_refs
 ):
     from soliket.cross_correlation import ShearKappaLikelihood
+
+    ref = likelihood_refs["shearkappa_ia_perbin"]
 
     evaluate_one_info["params"] = test_cosmology_params
     evaluate_one_info["theory"] = cross_correlation_theory
@@ -397,13 +411,15 @@ def test_shearkappa_ia_perbin(
     model = get_model(evaluate_one_info)
     loglikes, derived = model.loglikes()
 
-    assert np.isclose(loglikes[0], -100164.38521295182, atol=0.2, rtol=0.0)
+    assert np.isclose(loglikes[0], ref["value"], rtol=ref["rtol"], atol=ref["atol"])
 
 
 def test_shearkappa_hmcode(
-    request, check_skip_pyccl, evaluate_one_info, test_cosmology_params
+    request, check_skip_pyccl, evaluate_one_info, test_cosmology_params, likelihood_refs
 ):
     from soliket.cross_correlation import ShearKappaLikelihood
+
+    ref = likelihood_refs["shearkappa_hmcode"]
 
     evaluate_one_info["params"] = test_cosmology_params
     evaluate_one_info["theory"] = cross_correlation_theory
@@ -424,4 +440,4 @@ def test_shearkappa_hmcode(
     model = get_model(evaluate_one_info)
     loglikes, derived = model.loglikes()
 
-    assert np.isclose(loglikes[0], -20679.897354035915, atol=0.2, rtol=0.0)
+    assert np.isclose(loglikes[0], ref["value"], rtol=ref["rtol"], atol=ref["atol"])

--- a/tests/test_lensing.py
+++ b/tests/test_lensing.py
@@ -26,7 +26,7 @@ def test_lensing_import(request):
     _ = importlib.import_module("soliket.lensing").LensingLikelihood
 
 
-def test_lensing_like(request):
+def test_lensing_like(request, likelihood_refs):
     from cobaya.install import install
 
     install(
@@ -40,11 +40,13 @@ def test_lensing_like(request):
 
     from soliket.lensing import LensingLikelihood
 
+    ref = likelihood_refs["lensing"]
+
     info["likelihood"] = {"LensingLikelihood": {"external": LensingLikelihood}}
     model = get_model(info)
     loglikes, derived = model.loglikes()
 
-    assert np.isclose(loglikes[0], 335.8560097798468, atol=0.2, rtol=0.0)
+    assert np.isclose(loglikes[0], ref["value"], rtol=ref["rtol"], atol=ref["atol"])
 
 
 def test_lensing_ccl_limber(check_skip_pyccl):

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -60,7 +60,9 @@ def test_lensing_and_mflike_installations(check_skip_mflike):
     )
 
 
-def test_multi(test_cosmology_params, check_skip_mflike):
+def test_multi(test_cosmology_params, check_skip_mflike, likelihood_refs):
+    ref = likelihood_refs["multi"]
+
     lensing_options = {"theory_lmax": 5000}
 
     mflike_options = {
@@ -124,7 +126,7 @@ def test_multi(test_cosmology_params, check_skip_mflike):
     logp_a = model.loglikes(fg_values_a, cached=False)[0].sum()
     logp_b = model.loglikes(fg_values_b, cached=False)[0].sum()
     d_logp = logp_b - logp_a
-    assert np.isclose(d_logp, -503.395, rtol=1e-4)
+    assert np.isclose(d_logp, ref["value"], rtol=ref["rtol"], atol=ref["atol"])
 
     model1_logp_a = model1.loglikes(fg_values_a, cached=False)[0].sum()
     model2_logp_a = model2.loglikes({}, cached=False)[0].sum()


### PR DESCRIPTION
This PR fixes: #32, #113.

It adds global settings for the tolerance used to test the stability of likelihoods and collects all the reference values in the same place. In particular, I define a `yaml` file in `tests` that contains all this. The info is then passed to the tests through a fixture.

If needed, it is possible to set individually the tolerances of each test, but by default, they are set to the global values.

I said "partially" for the #32 because there it was suggested to have multiple points in parameter space, while we currently have only one. Still, I am not sure we still want to go for multiple points.