### PR TITLE
lensing: extract N0/N1 bias correction into LensingCorrections container

### DIFF
--- a/soliket/lensing/__init__.py
+++ b/soliket/lensing/__init__.py
@@ -1,1 +1,2 @@
+from ._corrections import LensingCorrections
 from .lensing import LensingLikelihood, LensingLiteLikelihood

--- a/soliket/lensing/_corrections.py
+++ b/soliket/lensing/_corrections.py
@@ -1,0 +1,92 @@
+"""N0/N1 lensing bias correction, decoupled from the likelihood.
+
+The full ``LensingLikelihood`` corrects its binned :math:`C_L^{\\kappa\\kappa}`
+theory for the response of the lensing estimator to deviations of the CMB spectra
+(:math:`N_0`) and of :math:`C_L^{\\kappa\\kappa}` (:math:`N_1`) away from the
+fiducial spectra used to compute its normalisation (see Sec. 5.9 / App. E of
+`Qu et al. 2023 <https://arxiv.org/abs/2304.05202>`_).
+
+:class:`LensingCorrections` bundles the static, cosmology-independent inputs (the
+:math:`N_0`/:math:`N_1` response matrices keyed by spectrum, the fiducial spectra
+and the normalisation) and exposes :meth:`compute`, which applies them to a
+per-step theory vector. :meth:`compute` is free of SACC / cobaya coupling so it
+can be built and called externally (e.g. from the simulation notebooks) and
+unit-tested in isolation; :meth:`from_sacc` is the adapter that reads the shipped
+correction file. The likelihood builds one with ``from_sacc`` and calls
+``compute`` each step.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+# Spectra carrying both an N0 and an N1 response, and the (tracer1, tracer2,
+# data_type) triple naming each in the correction SACC.
+_N0_SACC = {
+    "tt": ("ct", "ct", "N0_00"),
+    "te": ("ct", "ce", "N0_0e"),
+    "ee": ("ce", "ce", "N0_ee"),
+    "bb": ("cb", "cb", "N0_bb"),
+}
+_N1_SACC = {
+    "tt": ("ct", "ct", "N1_00"),
+    "te": ("ct", "ce", "N1_0e"),
+    "ee": ("ce", "ce", "N1_ee"),
+    "bb": ("cb", "cb", "N1_bb"),
+}
+_SPECS = tuple(_N0_SACC)
+
+
+@dataclass(frozen=True)
+class LensingCorrections:
+    fiducial: dict[str, np.ndarray]  # fiducial CMB spectra, keyed "tt"/"te"/"ee"/"bb"
+    n0_response: dict[str, np.ndarray]  # N0 response matrix per spectrum
+    n1_response: dict[str, np.ndarray]  # N1 response matrix per spectrum
+    n1_clpp: np.ndarray  # N1 response to (Clkk - fiducial Clkk)
+    thetaclkk: np.ndarray  # fiducial C_L^kk
+    n0: np.ndarray  # estimator normalisation
+
+    def compute(
+        self,
+        *,
+        cls: dict[str, np.ndarray],
+        clkk_theo: np.ndarray,
+        binning_matrix: np.ndarray,
+    ) -> np.ndarray:
+        r"""Binned :math:`N_0`/:math:`N_1` correction for a theory step.
+
+        :param cls: theory CMB spectra (unbinned, to ``lmax``) keyed "tt"/"te"/"ee"/"bb".
+        :param clkk_theo: theory :math:`C_L^{\kappa\kappa}` (unbinned, to ``lmax``).
+        :param binning_matrix: bandpower binning matrix applied to the correction.
+        :return: the binned correction to add to the binned :math:`C_L^{\kappa\kappa}`.
+        """
+        delta = {s: cls[s] - self.fiducial[s] for s in self.fiducial}
+        n0_term = sum(self.n0_response[s] @ delta[s] for s in delta)
+        n1_term = self.n1_clpp @ (clkk_theo - self.thetaclkk) + sum(
+            self.n1_response[s] @ delta[s] for s in delta
+        )
+        correction = 2 * (self.thetaclkk / self.n0) * n0_term + n1_term
+        return binning_matrix @ correction
+
+    @classmethod
+    def from_sacc(
+        cls, s, *, fiducial: dict[str, np.ndarray]
+    ) -> "LensingCorrections":
+        """Build from a correction SACC and the (lmax-sliced) fiducial spectra.
+
+        :param s: a loaded :class:`sacc.Sacc` holding the N0/N1 response spectra.
+        :param fiducial: fiducial spectra keyed "tt"/"te"/"ee"/"bb"/"kk".
+        """
+
+        def spec(tracer1, tracer2, data_type):
+            _, cl = s.get_ell_cl(data_type, tracer1, tracer2, return_cov=False)
+            return cl
+
+        return cls(
+            fiducial={key: fiducial[key] for key in _SPECS},
+            n0_response={key: spec(*_N0_SACC[key]) for key in _SPECS},
+            n1_response={key: spec(*_N1_SACC[key]) for key in _SPECS},
+            n1_clpp=spec("cp", "cp", "N1_00"),
+            thetaclkk=fiducial["kk"],
+            n0=spec("n0", "n0", "N0_00")[0],
+        )

--- a/soliket/lensing/lensing.py
+++ b/soliket/lensing/lensing.py
@@ -24,6 +24,8 @@ from cobaya.theory import Provider
 from soliket.ccl import CCL
 from soliket.gaussian import GaussianLikelihood
 
+from ._corrections import LensingCorrections
+
 
 class LensingLikelihood(GaussianLikelihood, InstallableLikelihood):
     r"""
@@ -130,36 +132,9 @@ class LensingLikelihood(GaussianLikelihood, InstallableLikelihood):
             s = sacc.Sacc.load_fits(
                 os.path.join(self.data_folder, self.correction_filename)
             )
-
-            _, self.N0cltt = self._get_spectrum_from_sacc(
-                s, "ct", "ct", data_type="N0_00"
+            self.corrections = LensingCorrections.from_sacc(
+                s, fiducial=self._fiducial_cls
             )
-            _, self.N0clte = self._get_spectrum_from_sacc(
-                s, "ct", "ce", data_type="N0_0e"
-            )
-            _, self.N0clee = self._get_spectrum_from_sacc(
-                s, "ce", "ce", data_type="N0_ee"
-            )
-            _, self.N0clbb = self._get_spectrum_from_sacc(
-                s, "cb", "cb", data_type="N0_bb"
-            )
-            _, self.N1clpp = self._get_spectrum_from_sacc(
-                s, "cp", "cp", data_type="N1_00"
-            )
-            _, self.N1cltt = self._get_spectrum_from_sacc(
-                s, "ct", "ct", data_type="N1_00"
-            )
-            _, self.N1clte = self._get_spectrum_from_sacc(
-                s, "ct", "ce", data_type="N1_0e"
-            )
-            _, self.N1clee = self._get_spectrum_from_sacc(
-                s, "ce", "ce", data_type="N1_ee"
-            )
-            _, self.N1clbb = self._get_spectrum_from_sacc(
-                s, "cb", "cb", data_type="N1_bb"
-            )
-            _, self.n0 = self._get_spectrum_from_sacc(s, "n0", "n0", data_type="N0_00")
-            self.n0 = self.n0[0]
         else:
             raise LoggedError(
                 self.log,
@@ -223,11 +198,9 @@ class LensingLikelihood(GaussianLikelihood, InstallableLikelihood):
             Cls = model_fiducial.provider.get_Cl(ell_factor=False)
             Cls["kk"] = Cls["pp"][0 : self.lmax] * (self.ls * (self.ls + 1)) ** 2 * 0.25
 
-        self.fcltt = Cls["tt"][0 : self.lmax]
-        self.fclee = Cls["ee"][0 : self.lmax]
-        self.fclte = Cls["te"][0 : self.lmax]
-        self.fclbb = Cls["bb"][0 : self.lmax]
-        self.thetaclkk = Cls["kk"][0 : self.lmax]
+        self._fiducial_cls = {
+            spec: Cls[spec][0 : self.lmax] for spec in ("tt", "ee", "te", "bb", "kk")
+        }
         return Cls
 
     def get_requirements(self) -> dict:
@@ -283,31 +256,13 @@ class LensingLikelihood(GaussianLikelihood, InstallableLikelihood):
             cmbk = ccl.CMBLensingTracer(cosmo, z_source=zstar)
             Clkk_theo = ccl.angular_cl(cosmo, cmbk, cmbk, self.ls)
 
-        Cl_tt = cl["tt"][0 : self.lmax]
-        Cl_ee = cl["ee"][0 : self.lmax]
-        Cl_te = cl["te"][0 : self.lmax]
-        Cl_bb = cl["bb"][0 : self.lmax]
-
         Clkk_binned = self.binning_matrix.dot(Clkk_theo)
 
-        correction = (
-            2
-            * (self.thetaclkk / self.n0)
-            * (
-                np.dot(self.N0cltt, Cl_tt - self.fcltt)
-                + np.dot(self.N0clee, Cl_ee - self.fclee)
-                + np.dot(self.N0clbb, Cl_bb - self.fclbb)
-                + np.dot(self.N0clte, Cl_te - self.fclte)
-            )
-            + np.dot(self.N1clpp, Clkk_theo - self.thetaclkk)
-            + np.dot(self.N1cltt, Cl_tt - self.fcltt)
-            + np.dot(self.N1clee, Cl_ee - self.fclee)
-            + np.dot(self.N1clbb, Cl_bb - self.fclbb)
-            + np.dot(self.N1clte, Cl_te - self.fclte)
+        correction = self.corrections.compute(
+            cls={spec: cl[spec][0 : self.lmax] for spec in ("tt", "te", "ee", "bb")},
+            clkk_theo=Clkk_theo,
+            binning_matrix=self.binning_matrix,
         )
-
-        # put the correction term into bandpowers
-        correction = self.binning_matrix.dot(correction)
 
         return Clkk_binned + correction
 

--- a/tests/test_lensing_corrections.py
+++ b/tests/test_lensing_corrections.py
@@ -1,0 +1,109 @@
+"""Unit tests for the decoupled lensing N0/N1 bias correction.
+
+These exercise ``LensingCorrections.compute`` in isolation -- no cobaya, no data
+download -- using small hand-computable inputs.
+"""
+
+import numpy as np
+
+from soliket.lensing import LensingCorrections
+
+_SPECS = ("tt", "te", "ee", "bb")
+
+
+def _corrections(
+    n,
+    *,
+    fiducial=None,
+    n0_response=None,
+    n1_response=None,
+    n1_clpp=None,
+    thetaclkk=None,
+    n0=None,
+):
+    """A LensingCorrections defaulting to zeros, with the given pieces overridden.
+
+    ``fiducial``/``n0_response``/``n1_response`` are merged onto all-zero defaults
+    so a test only specifies the spectra it cares about.
+    """
+    fid = {k: np.zeros(n) for k in _SPECS}
+    fid.update(fiducial or {})
+    n0r = {k: np.zeros((n, n)) for k in _SPECS}
+    n0r.update(n0_response or {})
+    n1r = {k: np.zeros((n, n)) for k in _SPECS}
+    n1r.update(n1_response or {})
+    return LensingCorrections(
+        fiducial=fid,
+        n0_response=n0r,
+        n1_response=n1r,
+        n1_clpp=np.zeros((n, n)) if n1_clpp is None else n1_clpp,
+        thetaclkk=np.zeros(n) if thetaclkk is None else thetaclkk,
+        n0=np.ones(n) if n0 is None else n0,
+    )
+
+
+def _cls(n, **overrides):
+    cls = {k: np.zeros(n) for k in _SPECS}
+    cls.update(overrides)
+    return cls
+
+
+def test_n0_term_scaling_and_response():
+    """The N0 response is scaled by 2 * thetaclkk / n0 applied to (Cl - fiducial)."""
+    n = 3
+    corr = _corrections(
+        n,
+        fiducial={"tt": np.array([1.0, 1.0, 1.0])},
+        thetaclkk=np.array([2.0, 2.0, 2.0]),
+        n0=np.array([1.0, 1.0, 1.0]),
+        n0_response={"tt": np.eye(n)},
+    )
+    # delta_tt = [1, 2, 3]; scale = 2 * 2 / 1 = 4
+    out = corr.compute(
+        cls=_cls(n, tt=np.array([2.0, 3.0, 4.0])),
+        clkk_theo=np.zeros(n),
+        binning_matrix=np.eye(n),
+    )
+
+    np.testing.assert_allclose(out, [4.0, 8.0, 12.0])
+
+
+def test_n1_clpp_term():
+    """The N1 lensing term applies n1_clpp to (Clkk_theo - thetaclkk) with no scaling."""
+    n = 3
+    corr = _corrections(
+        n,
+        thetaclkk=np.array([1.0, 1.0, 1.0]),
+        n0=np.array([1.0, 1.0, 1.0]),
+        n1_clpp=np.eye(n),
+    )
+    clkk_theo = np.array([3.0, 4.0, 5.0])  # delta = [2, 3, 4]
+
+    out = corr.compute(
+        cls=_cls(n),
+        clkk_theo=clkk_theo,
+        binning_matrix=np.eye(n),
+    )
+
+    np.testing.assert_allclose(out, [2.0, 3.0, 4.0])
+
+
+def test_binning_matrix_is_applied_last():
+    """The full correction vector is projected through the binning matrix."""
+    n = 3
+    corr = _corrections(
+        n,
+        fiducial={"tt": np.array([1.0, 1.0, 1.0])},
+        thetaclkk=np.array([2.0, 2.0, 2.0]),
+        n0=np.array([1.0, 1.0, 1.0]),
+        n0_response={"tt": np.eye(n)},
+    )
+    binning = np.array([[1.0, 1.0, 0.0], [0.0, 0.0, 1.0]])  # 2 bins x 3
+
+    out = corr.compute(
+        cls=_cls(n, tt=np.array([2.0, 3.0, 4.0])),  # unbinned correction = [4, 8, 12]
+        clkk_theo=np.zeros(n),
+        binning_matrix=binning,
+    )
+
+    np.testing.assert_allclose(out, [12.0, 12.0])  # [4+8, 12]


### PR DESCRIPTION
## Summary
Closes #60.

Extracts the N0/N1 lensing bias correction out of `LensingLikelihood._get_theory` into a self-contained `LensingCorrections` dataclass (`soliket/lensing/_corrections.py`). This addresses the last open item of #60 (the other three — sacc data, sacc corrections, optional fiducial-from-file — are already done on master) **without** adding a cobaya `Theory` to maintain.

Behaviour is unchanged: the end-to-end lensing likelihood tests pass against the same reference loglikes.

## What changed
- **New `LensingCorrections`** holding the static, cosmology-independent inputs (N0/N1 response matrices grouped as per-spectrum dicts, fiducial spectra, normalisation):
  - `compute(cls, clkk_theo, binning_matrix)` — pure kernel, free of sacc/cobaya coupling, so it's unit-testable and callable externally (e.g. from the simulation notebooks).
  - `from_sacc(s, fiducial)` — adapter owning the sacc `(tracer, tracer, data_type)` → spectrum mapping.
- **`LensingLikelihood`** slimmed by ~56 lines: `_set_correction_factors` is now a single `from_sacc` call, `_get_theory` a single `compute` call, and the fiducial spectra are stored as one dict.
- **New unit tests** (`tests/test_lensing_corrections.py`) exercising the correction in isolation; `from_sacc` is covered by the existing end-to-end lensing test.

## Test plan
- [x] `pytest tests/test_lensing.py tests/test_lensing_lite.py tests/test_lensing_corrections.py` → 10 passed, 1 skipped (pyccl path)
- [x] `ruff check` clean
- [x] End-to-end loglikes match references (behaviour-preserving)
