### PR TITLE
options: enable _enforce_types and complete option type annotations for xcorr, ccl_tracers, cosmopower

### DIFF
--- a/soliket/ccl_tracers/ccl_tracers.py
+++ b/soliket/ccl_tracers/ccl_tracers.py
@@ -30,6 +30,8 @@ class CCLTracersLikelihood(GaussianLikelihood):
     ncovsims: int | None
     provider: Provider
 
+    _enforce_types: bool = True
+
     def initialize(self):
         super().initialize()
 

--- a/soliket/cosmopower/CosmoPowerDerived.yaml
+++ b/soliket/cosmopower/CosmoPowerDerived.yaml
@@ -8,10 +8,6 @@ network_settings:
   type: NN   # Either NN or PCAplusNN, depending on the network type
   log: false # Set this to true if this network calculates log(X) for all parameters X.
 
-# Optional extra arguments for the theory code.
-extra_args:
-  # (Currently, no extra arguments exist yet for the derived network).
-
 # A list of all names for the derived parameters of this network.
 derived_parameters: []
 

--- a/soliket/cosmopower/cosmopower.py
+++ b/soliket/cosmopower/cosmopower.py
@@ -108,6 +108,9 @@ except ImportError:
 class CosmoPower(BoltzmannBase):
     """A CosmoPower Network wrapper for Cobaya."""
 
+    network_path: str
+    network_settings: dict | None
+
     _enforce_types: bool = True
 
     def initialize(self):
@@ -299,6 +302,13 @@ class CosmoPower(BoltzmannBase):
 
 class CosmoPowerDerived(Theory):
     """A theory class that can calculate derived parameters from CosmoPower networks."""
+
+    network_path: str
+    network_settings: dict | None
+    derived_parameters: list[str]
+    renames: dict
+
+    _enforce_types: bool = True
 
     def initialize(self):
         super().initialize()

--- a/soliket/xcorr/xcorr.py
+++ b/soliket/xcorr/xcorr.py
@@ -70,10 +70,10 @@ class XcorrLikelihood(GaussianLikelihood):
     Nchi: int | None
     Nchi_mag: int | None
     Pk_interp_kmax: int | float | None
-    b1: int | float
-    s1: int | float
 
     provider: Provider
+
+    _enforce_types: bool = True
 
     _allowable_tracers = ("cmb_convergence", "galaxy_density")
 

--- a/tests/test_options_validation.py
+++ b/tests/test_options_validation.py
@@ -1,0 +1,48 @@
+"""Option type-validation is enabled (``_enforce_types``) for xcorr and ccl_tracers.
+
+These components declare their options as typed class attributes; with
+``_enforce_types`` set, cobaya type-checks the attribute values at init, so a
+mistyped option is caught instead of silently accepted.
+"""
+
+import pytest
+
+from soliket.ccl_tracers.ccl_tracers import CCLTracersLikelihood
+from soliket.cosmopower.cosmopower import CosmoPower, CosmoPowerDerived
+from soliket.xcorr.xcorr import XcorrLikelihood
+
+
+def _validate_with(cls, **attrs):
+    """Run cobaya's attribute validation on a bare instance with the given attrs."""
+    inst = cls.__new__(cls)
+    for name, value in attrs.items():
+        setattr(inst, name, value)
+    inst.validate_attributes(cls.get_annotations())
+
+
+def test_xcorr_enforces_option_types():
+    assert XcorrLikelihood._enforce_types is True
+    # high_ell is annotated int | None; a string must be rejected.
+    with pytest.raises(TypeError):
+        _validate_with(XcorrLikelihood, high_ell="not-an-int")
+
+
+def test_ccl_tracers_enforces_option_types():
+    assert CCLTracersLikelihood._enforce_types is True
+    # ncovsims is annotated int | None; a string must be rejected.
+    with pytest.raises(TypeError):
+        _validate_with(CCLTracersLikelihood, ncovsims="not-an-int")
+
+
+def test_cosmopower_enforces_option_types():
+    assert CosmoPower._enforce_types is True
+    # network_path is annotated str; an int must be rejected.
+    with pytest.raises(TypeError):
+        _validate_with(CosmoPower, network_path=123)
+
+
+def test_cosmopower_derived_enforces_option_types():
+    assert CosmoPowerDerived._enforce_types is True
+    # derived_parameters is annotated list[str]; an int must be rejected.
+    with pytest.raises(TypeError):
+        _validate_with(CosmoPowerDerived, derived_parameters=123)


### PR DESCRIPTION
## Summary
Closes #162.

Completes the migration of component option declarations to typed class attributes with validation. Most components (`CCL`, `Bias`, `HaloModel`, `CosmoPower`) already declared options as type annotations with `_enforce_types = True`; this brings the stragglers in line so **all** components type-check their options.

Per the design discussion, this is scoped to **options only**: default values stay in the yaml files, and parameter specs (priors/refs/fixed values) stay in yaml/presets. No values were moved into class attributes.

## What changed
- **`xcorr`**: enable `_enforce_types`; remove the vacuous `b1`/`s1` annotations (they're sampled params delivered via `params_values`, never set as attributes, so the annotations validated nothing and were misleading).
- **`ccl_tracers`**: enable `_enforce_types` on the base `CCLTracersLikelihood` (inherited by Galaxy/ShearKappa).
- **`cosmopower`**: annotate the previously-unvalidated options — `network_path`, `network_settings` (both classes), `derived_parameters`, `renames` (Derived); enable `_enforce_types` on `CosmoPowerDerived`; drop the unused `extra_args` from `CosmoPowerDerived.yaml`.
- **Tests**: `tests/test_options_validation.py` verifies a mistyped option now raises for each touched class.
