### PR TITLE
[skipci] Fix packages path and cache cobaya data in Compatibility workflow

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -2,6 +2,11 @@ name: Compatibility
 on:
   schedule:
     - cron: '0 4 * * SUN'
+  workflow_dispatch:
+
+env:
+  COBAYA_PACKAGES_PATH: ./cobaya_packages
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -22,11 +27,22 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+      - name: Resolve MFLike version for cache key
+        id: mflike-version
+        shell: bash
+        run: |
+          VERSION=$(grep -A1 '^name = "mflike"$' uv.lock | grep '^version' | head -1 | sed -E 's/version = "(.*)"/\1/')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Cache cobaya_packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: ./cobaya_packages
+          # Same key as testing.yml, so the weekly run reuses the data cache
+          # populated on master instead of re-downloading from portal.nersc.gov.
+          key: cobaya_packages-${{ runner.os }}-${{ matrix.python-version }}-mflike-${{ steps.mflike-version.outputs.version }}
       - name: Install dependencies
         run: |
           bash ci_scripts/install_deps.sh --extras dev emulator
       - name: Run tests
-        env:
-          COBAYA_PACKAGES_PATH: ./cobaya_packages
         run: |
           uv run pytest -vv --durations=10


### PR DESCRIPTION
The weekly `Compatibility` run has been failing on `master` for at least two
weeks ([2026-08-02](https://github.com/simonsobs/SOLikeT/actions/runs/30733446982),
and 2026-07-26 before it). It is not a dependency incompatibility — the workflow
itself is misconfigured, so the signal has been dead noise.

### The bug

Both matrix jobs die in *Install dependencies* with:

```
cobaya.log.LoggedError: No 'path' argument given, and none could be found in input
infos (as 'packages_path'), the 'COBAYA_PACKAGES_PATH' env variable or the config file
```

`testing.yml` declares `COBAYA_PACKAGES_PATH` at **workflow** level, so it is
visible to every step. `compatibility.yml` declared it only on the *Run tests*
step — but `ci_scripts/install_likelihoods.sh` invokes
`cobaya-install ... --no-set-global` with no `-p`, so the **install** step had
nowhere to write and failed instantly on all three retry attempts. No network
involved; the job never got as far as downloading anything.

### Changes

- Move `COBAYA_PACKAGES_PATH` to workflow level, mirroring `testing.yml`, and
  drop the now-redundant step-level copy. This is the actual fix.
- Add a `cobaya_packages` cache using the **same key** as `testing.yml`. The
  weekly run had no cache at all, so it always cold-hit `portal.nersc.gov` for
  the MFLike data. Sharing the key means it reuses the cache already populated
  on `master`, which removes the dependence on that server being up. (It is
  returning 503 as I write this, which is separately blocking #279/#280/#281.)
- Add `workflow_dispatch` so this workflow can be triggered manually instead of
  only at 04:00 on Sundays. Not being able to run it on demand is a large part
  of why the breakage went unnoticed.

### Verification

- YAML parses; triggers are `schedule` + `workflow_dispatch`, workflow-level
  `env` is set, and no step-level `env` remains.
- The cache-key expression is byte-identical to the one in `testing.yml`, and
  the resolver returns `1.0.2` locally — matching the `cobaya_packages-Linux-3.11-mflike-1.0.2`
  key seen in CI logs, so the keys really do coincide.
- Once merged, `workflow_dispatch` lets us confirm the fix directly rather than
  waiting for Sunday.

`[skipci]`: this touches only the scheduled `Compatibility` workflow and cannot
affect the `testing.yml` matrix.
