### PR TITLE
Make Compatibility workflow install all extras and resolve latest deps

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -33,16 +33,23 @@ jobs:
         run: |
           VERSION=$(grep -A1 '^name = "mflike"$' uv.lock | grep '^version' | head -1 | sed -E 's/version = "(.*)"/\1/')
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-      - name: Cache cobaya_packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+      - name: Restore cobaya_packages
+        # Restore-only, on purpose. This job installs with --latest, so the
+        # mflike version it ends up with is not known until after the sync and
+        # may differ from the one this key was derived from. Saving here could
+        # therefore store mismatched data under a key testing.yml also uses, so
+        # we only ever read. A miss just means a fresh download.
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: ./cobaya_packages
-          # Same key as testing.yml, so the weekly run reuses the data cache
-          # populated on master instead of re-downloading from portal.nersc.gov.
           key: cobaya_packages-${{ runner.os }}-${{ matrix.python-version }}-mflike-${{ steps.mflike-version.outputs.version }}
       - name: Install dependencies
+        # --extras dev all: install_likelihoods.sh installs mflike data, which
+        # needs the mflike extra; 'emulator' alone does not provide it.
+        # --latest: re-resolve instead of using the lockfile, so this run can
+        # actually catch upstream releases breaking us.
         run: |
-          bash ci_scripts/install_deps.sh --extras dev emulator
+          bash ci_scripts/install_deps.sh --extras dev all --latest
       - name: Run tests
         run: |
           uv run pytest -vv --durations=10

--- a/ci_scripts/install_deps.sh
+++ b/ci_scripts/install_deps.sh
@@ -4,6 +4,11 @@ set -e
 # Parse args (simple)
 EXTRAS=()
 
+# Default to the pinned lockfile. The weekly Compatibility run passes --latest
+# to re-resolve to the newest versions our pyproject constraints allow, which is
+# the only way it can actually detect upstream breakage.
+SYNC_MODE="--locked"
+
 while [[ $# -gt 0 ]]; do
   case $1 in
     --extras)
@@ -12,6 +17,10 @@ while [[ $# -gt 0 ]]; do
         EXTRAS+=("$1")
         shift
       done
+      ;;
+    --latest)
+      SYNC_MODE="--upgrade"
+      shift
       ;;
     *)
       echo "Unknown argument: $1"
@@ -26,9 +35,9 @@ for e in "${EXTRAS[@]}"; do
   EXTRAS_STR+="--extra $e "
 done
 
-echo "Installing with extras: $EXTRAS_STR"
+echo "Installing with extras: $EXTRAS_STR (uv sync $SYNC_MODE)"
 
-uv sync --locked $EXTRAS_STR
+uv sync $SYNC_MODE $EXTRAS_STR
 
 # Call common installer of likelihoods
 bash "$(dirname "$0")/install_likelihoods.sh"


### PR DESCRIPTION
Follow-up to #283. That PR fixed `COBAYA_PACKAGES_PATH` and let the weekly
`Compatibility` workflow get as far as installing likelihoods — which promptly
exposed a second, independent bug underneath.

### Bug: it installs extras that cannot satisfy its own install step

Manually dispatching the workflow after #283 gave:

```
[install] *ERROR* 'mflike.TTTEEE' could not be found. Tried loading internal and
external classes. No component path was given.
```

`compatibility.yml` installed `--extras dev emulator`, but `mflike` is provided by
the **`mflike`** extra (see `[project.optional-dependencies]`), which only `all`
pulls in. The shared `ci_scripts/install_likelihoods.sh` then unconditionally runs
`cobaya-install mflike.TTTEEE` on Python < 3.13. So the workflow installed
cosmopower but never mflike, then tried to install mflike's data — and failed
before reaching any download. **It could not have passed regardless of #283.**

### The design problem behind it

Simply widening to `all` would make it green but pointless: `install_deps.sh` runs
`uv sync --locked`, and the matrix is ubuntu 3.10/3.11 — both already covered by
`testing.yml` on every push, against the very same pinned versions. It would be a
weekly re-run of a config we already test, which is presumably not what a workflow
called *Compatibility* is for.

### Changes

- `install_deps.sh`: add an opt-in `--latest` flag that swaps `uv sync --locked`
  for `uv sync --upgrade`. The default is unchanged, so `testing.yml` keeps
  installing the pinned lockfile exactly as before.
- `compatibility.yml`: install `--extras dev all --latest`. The workflow now
  re-resolves to the newest versions our `pyproject.toml` constraints allow, so it
  can actually detect an upstream release breaking us — which is the signal the
  weekly cadence was presumably meant to provide.
- Downgrade the cache added in #283 to **restore-only** (`actions/cache/restore`).
  With `--latest` the resulting mflike version is not known until after the sync
  and may differ from the one the cache key was derived from. Saving would risk
  storing mismatched data under a key `testing.yml` also uses, so this job now
  only ever reads. A miss just means a fresh download.

### Verification

- `install_deps.sh` arg parsing tested against a stubbed `uv`. The default is
  byte-identical to before, and `--latest` is order-independent:
  - `--extras dev all`            -> `uv sync --locked --extra dev --extra all`
  - `--extras dev all --latest`   -> `uv sync --upgrade --extra dev --extra all`
  - `--latest --extras dev all`   -> `uv sync --upgrade --extra dev --extra all`
  - unknown arg still exits 1
- `-U, --upgrade` confirmed as a valid `uv sync` flag on uv 0.11.
- `compatibility.yml` parses; `env` is workflow-level and no step-level `env`
  remains.

### Note on CI

`portal.nersc.gov` is currently returning **503 across the whole host**, so the
MFLike data download fails and the test matrix cannot go green — this is what is
also blocking #279/#280/#281. Tests are deliberately *not* skipped here, since
this touches `install_deps.sh` which `testing.yml` uses. Please hold the merge
until NERSC is back and CI is genuinely green.
