### PR TITLE
[skipci] Install likelihood data in quickstart and create_datasets notebooks

### DIFF
--- a/notebooks/ISO_sims/create_datasets.ipynb
+++ b/notebooks/ISO_sims/create_datasets.ipynb
@@ -309,6 +309,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "00b2d044",
+   "source": [
+    "> **First run:** this section and section 3 need the MFLike and CMB-lensing likelihood data (~500 MB\n",
+    "> for MFLike, plus the lensing auxiliary files, fetched from NERSC). Section 1 above is pure CCL and\n",
+    "> needs none of it, which is why the install sits here rather than at the top. The cell below is a\n",
+    "> no-op once the data is present, and the downstream ISO notebooks reuse the same packages path."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "28dc8438",
+   "source": [
+    "from cobaya.install import install\n",
+    "from cobaya.tools import resolve_packages_path\n",
+    "\n",
+    "from soliket.presets import build_info\n",
+    "\n",
+    "# Install the two members separately, NOT via build_info(\"multigaussian\"): that preset\n",
+    "# nests them in `MultiGaussianLikelihood.components`, where cobaya's installer cannot\n",
+    "# see them -- it reports success while downloading nothing.\n",
+    "for preset in (\"mflike\", \"lensing\"):\n",
+    "    install(build_info(preset), path=resolve_packages_path())"
+   ],
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "727f439c",

--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -17,6 +17,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "92b48ad3",
+   "source": [
+    "> **First run:** the MFLike likelihood needs its data (~500 MB, fetched from NERSC), so the cell\n",
+    "> below installs it before anything else uses it. It is a no-op once the data is present, so it is\n",
+    "> safe to re-run. `_nb` is `notebooks/_nb.py`, the repo-only notebook helpers."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "dbfeac64",
+   "source": [
+    "import _nb\n",
+    "\n",
+    "_nb.install_data(\"mflike\")  # downloads the data on first run; a no-op afterwards"
+   ],
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "0e6914de",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Closes #278.

`quickstart.ipynb` failed for anyone who did not already have the MFLike data installed:
its very first code cell calls `quickstart("mflike")`, which needs the data, and nothing
in the notebook installed it. `first_step_tutorial.ipynb` already does this for the user,
so the two notebooks disagreed on prerequisites.

While there, `ISO_sims/create_datasets.ipynb` had the same gap: it calls
`resolve_packages_path()` in six places and reads
`packages_path/data/MFLike/v0.8/LAT_simu_sacc_00000.fits` directly, but never installs
anything.

### Changes

**`notebooks/quickstart.ipynb`** — an install cell before section 1, using the existing
`_nb.install_data` helper (`notebooks/_nb.py` is already advertised in section 3 as holding
"data download"), so no new machinery:

```python
import _nb

_nb.install_data("mflike")  # downloads the data on first run; a no-op afterwards
```

**`notebooks/ISO_sims/create_datasets.ipynb`** — an install cell at the start of section 2,
where the data first becomes necessary. Deliberately *not* at the top: section 1 is pure CCL
and reads only the in-repo `tests/data/unwise_g-so_kappa.sim.sacc.fits`, so it still runs with
no download at all. ISO notebooks cannot `import _nb` (it lives one directory up), so this
cell uses `cobaya.install` + `build_info` directly — the same idiom the next cell already uses.

### A trap worth knowing about

The obvious one-liner for `create_datasets` would be
`install(build_info("multigaussian"), ...)`, since that preset covers both members. **It
silently installs nothing for them.** `multigaussian` nests its members inside
`MultiGaussianLikelihood.components`, where cobaya's installer cannot see them — it reports
the wrapper as "a fully built-in component: nothing to do" and returns `True`:

```
theory:camb
theory:mflike.BandpowerForeground
likelihood:soliket.gaussian.MultiGaussianLikelihood   <- nothing to do
-> True
```

versus installing the members individually, which does reach the data:

```
likelihood:mflike.TTTEEE                 -> External dependencies ... installed
likelihood:soliket.LensingLikelihood     -> External dependencies ... installed
```

So the cell loops over `("mflike", "lensing")`, with a comment recording why. The structural
invariant this relies on is already locked by
`tests/test_presets.py::test_multigaussian_composes_options_from_members_in_component_order`,
which asserts `components == ["mflike.TTTEEE", "soliket.LensingLikelihood"]`.

### Verification

- Both new cells executed in their own working directories: `_nb.install_data("mflike")`
  returns `True`, and the loop reaches `mflike.TTTEEE` and `soliket.LensingLikelihood`. Both
  are idempotent ("Doing nothing" when the data is present), so re-running is safe.
- Ran quickstart's install cell followed by the cell it was blocking:
  `quickstart("mflike")` builds and `s.loglike()` returns `-3594.2377`.
- `ruff check` passes on both notebooks; `nbformat.validate` passes. Pure insertions
  (+52/-0) — no existing cell touched, and no outputs added.

### Notes

- `[skipci]`: notebook-only change. The test suite never executes these tutorials
  (`tests/test_nb.py` covers `notebooks/_nb.py`'s helpers, not the notebooks), and
  `portal.nersc.gov` is still returning 503 so the matrix cannot go green regardless. `ruff`
  still runs, since Code Style has no skip gate.
- Pre-existing, untouched: both notebooks are already `ruff format --check` dirty at `HEAD`
  (part of the wider drift caused by Code Style running `ruff format` without `--check`), and
  `create_datasets.ipynb` has two cells with no `id` field.
- `_nb.install_data` and `_nb.packages_path` have no test coverage. Not addressed here.
